### PR TITLE
Make TitleButton Draggable

### DIFF
--- a/UI/EavesdropperDedicatedFrame.xml
+++ b/UI/EavesdropperDedicatedFrame.xml
@@ -124,7 +124,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					</Button>
 
 					<!-- Title Button -->
-					<Button parentKey="TitleButton">
+					<Button parentKey="TitleButton" registerForDrag="LeftButton">
 						<Size x="110" y="15"/>
 						<Anchors>
 							<Anchor point="TOPLEFT"/>
@@ -140,6 +140,12 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 							<OnLeave>
 								self:GetParent():GetParent():OnLeave();
 							</OnLeave>
+							<OnDragStart>
+								self:GetParent():GetParent():OnDragStart();
+							</OnDragStart>
+							<OnDragStop>
+								self:GetParent():GetParent():OnDragStop();
+							</OnDragStop>
 						</Scripts>
 
 						<Layers>

--- a/UI/EavesdropperFrame.xml
+++ b/UI/EavesdropperFrame.xml
@@ -86,7 +86,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					</Button>
 
 					<!-- Title Button -->
-					<Button parentKey="TitleButton">
+					<Button parentKey="TitleButton" registerForDrag="LeftButton">
 						<Size x="110" y="15"/>
 						<Anchors>
 							<Anchor point="TOPLEFT"/>
@@ -102,6 +102,12 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 							<OnLeave>
 								self:GetParent():GetParent():OnLeave();
 							</OnLeave>
+							<OnDragStart>
+								self:GetParent():GetParent():OnDragStart();
+							</OnDragStart>
+							<OnDragStop>
+								self:GetParent():GetParent():OnDragStop();
+							</OnDragStop>
 						</Scripts>
 
 						<Layers>

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -255,8 +255,7 @@ end
 
 ---Begin moving the frame; only fires from the title bar when not locked
 function Eavesdropper_SharedFrameMixin:OnDragStart()
-	local isTitlebar = GetMouseFoci()[1] == self.TitleBar;
-	if self:IsWindowLocked() or not isTitlebar then return; end
+	if self:IsWindowLocked() then return; end;
 
 	self:StopMovingOrSizing();
 	self:StartMoving();

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -255,7 +255,7 @@ end
 
 ---Begin moving the frame; only fires from the title bar when not locked
 function Eavesdropper_SharedFrameMixin:OnDragStart()
-	if self:IsWindowLocked() then return; end;
+	if self:IsWindowLocked() then return; end
 
 	self:StopMovingOrSizing();
 	self:StartMoving();

--- a/UI/EavesdropperGroupFrame.xml
+++ b/UI/EavesdropperGroupFrame.xml
@@ -151,7 +151,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					</Button>
 
 					<!-- Title Button -->
-					<Button parentKey="TitleButton">
+					<Button parentKey="TitleButton" registerForDrag="LeftButton">
 						<Size x="110" y="15"/>
 						<Anchors>
 							<Anchor point="TOPLEFT"/>
@@ -167,6 +167,12 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 							<OnLeave>
 								self:GetParent():GetParent():OnLeave();
 							</OnLeave>
+							<OnDragStart>
+								self:GetParent():GetParent():OnDragStart();
+							</OnDragStart>
+							<OnDragStop>
+								self:GetParent():GetParent():OnDragStop();
+							</OnDragStop>
 						</Scripts>
 
 						<Layers>


### PR DESCRIPTION
Allow dragging the TitleButton to move the window.

## Concept of a Test Plan

- [x] Dragging the TitleButton will move the window.
- [x] While dragging, releasing the left button on the title button will not trigger its `OnClick`.