### PR TITLE
Allow Mouse Pass Through Hyperlink in Ghost Mode

### DIFF
--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -247,6 +247,15 @@ function Eavesdropper_SharedFrameMixin:UpdateMouseLock()
 			self:SetMouseMotionEnabled(true);
 		end
 	end
+
+	-- Enable/Disable OnHyperlinkClick
+	-- This delay is essential otherwise it won't take effect
+	RunNextFrame(function()
+		self:SetHyperlinksEnabled(isEnabled);
+		if self.ChatBox then
+			self.ChatBox:SetHyperlinksEnabled(isEnabled);
+		end
+	end);
 end
 
 -- ============================================================


### PR DESCRIPTION
This PR allows mouse clicks to pass through hyperlinks when "Enable Mouse" is disabled.

## Concept of a Test Plan

- [x] Disable "Enable Mouse", click on a hyperlink, and you are still able to move the camera.
- [x] Enable "Enable Mouse", clicking on a hyperlink will execute it.
- [x] Toggle "Enable Mouse" on/off again to see if it works.
- [ ] Drink water?