### PR TITLE
Fix attempt for Name Break / Color Overflow

### DIFF
--- a/Core/ChatFormatter.lua
+++ b/Core/ChatFormatter.lua
@@ -46,7 +46,7 @@ end
 ---@return string
 local function MsgFormatEmote(entry, name)
 	local msg = entry.m or "";
-	local shortName = string.trim(name:match("^[^-]+") or name);
+	local shortName = strtrim(name);
 
 	local nameDisplayMode = ED.Database:GetSetting("NameDisplayMode");
 	local useRPName = nameDisplayMode ~= 3;
@@ -100,7 +100,7 @@ end
 ---@return string
 local function MsgFormatEmoteGroup(entry, name)
 	local result = MsgFormatEmote(entry, name);
-	local shortName = strtrim(name:match("^[^-]+") or name);
+	local shortName = name;
 
 	---Strip WoW colour escapes for a plain-text prefix check.
 	local plainResult = result:gsub("|c%x%x%x%x%x%x%x%x", ""):gsub("|r", "");
@@ -123,7 +123,7 @@ local function MsgFormatTextEmote(entry, name)
 	local shortName;
 
 	if entry.e == "ROLL" or unitName ~= entry.s then
-		shortName = name:match("^[^-]+") or name;
+		shortName = name;
 		local firstSpace = messageText:find(" ", 1, true) or 0;
 		messageText = messageText:sub(firstSpace + 1);
 	end
@@ -161,7 +161,7 @@ end;
 ---@return string
 local function MsgFormatTextEmoteGroup(entry, name)
 	local messageText = entry.m or "";
-	local shortName = name:match("^[^-]+") or name;
+	local shortName = name;
 
 	---Always strip the leading sender token for group display.
 	local firstSpace = messageText:find(" ", 1, true) or 0;


### PR DESCRIPTION
This PR attempts to close by making adjustments to how the ChatFormatter handles symbols in the name. (since apparently I can't type in the first attempt correctly)

By the time name reaches any of these format functions, it has already been processed by GetFormattedName > StripRealmSuffix. The ^[^-]+ pattern was defensive realm-stripping on a name that no longer has a realm suffix.

Removing it means hyphenated RP names pass through intact and no longer overflow color into neighboring emotes due to truncated shortName being embedded into message body with its nameColor wrap.

### Before:
<img width="684" height="266" alt="image" src="https://github.com/user-attachments/assets/9c6f0e07-d405-4461-bcc5-150db8d0c191" />


### After:
<img width="687" height="88" alt="image" src="https://github.com/user-attachments/assets/ece46293-7a90-4d3f-988d-b79b23f4e510" />