### PR TITLE
Group Windows hide TRP3 NPC Speech names (like everywhere else)

### DIFF
--- a/Core/ChatFormatter.lua
+++ b/Core/ChatFormatter.lua
@@ -88,8 +88,9 @@ end
 ---Formats an emote message, prepending the sender short-name and handling split markers and RP colour.
 ---@param entry EavesdropperChatEntry
 ---@param name string
+---@param forGroup boolean? If true, called from a group context.
 ---@return string
-local function MsgFormatEmote(entry, name)
+local function MsgFormatEmote(entry, name, forGroup)
 	local msg = entry.m or "";
 
 	local nameDisplayMode = ED.Database:GetSetting("NameDisplayMode");
@@ -118,8 +119,10 @@ local function MsgFormatEmote(entry, name)
 		end
 	end
 
-	-- Skip prepending name for punctuation-starting messages.
-	if msg:match("^%s*%p") then return msg; end
+	-- Skip prepending name for punctuation-starting messages by default;
+	-- only show the name when in a group context and the user setting is enabled.
+	local skipName = not (forGroup and ED.Database:GetGlobalSetting("GroupWindowsNPCSpeechDetectionNameShown"));
+	if skipName and msg:match("^%s*%p") then return msg; end
 
 	return name .. " " .. msg;
 end
@@ -130,7 +133,7 @@ end
 ---@param name string
 ---@return string
 local function MsgFormatEmoteGroup(entry, name)
-	local result = MsgFormatEmote(entry, name);
+	local result = MsgFormatEmote(entry, name, true);
 
 	--[[
 	Kept for archival purposes (for now), this adds names for multi-msg.

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -29,6 +29,8 @@ local Database = {};
 ---@field GroupWindowsPersist boolean?
 ---@field MinimapButton EavesdropperGlobalMinimapButton?
 ---@field SettingsWindowPosition EavesdropperWindowPosition?
+---@field GroupWindowsNPCSpeechDetectionNameShown boolean?
+---@field GroupWindowsPersist boolean?
 ---@field WelcomeMessage boolean?
 
 ---@type EavesdropperGlobal
@@ -39,6 +41,7 @@ local GLOBAL_DEFAULTS = {
 	DedicatedWindowsPersist = true,
 	GroupWindows = true,
 	GroupWindowsNewIndicator = true,
+	GroupWindowsNPCSpeechDetectionNameShown = false,
 	GroupWindowsUnitPopups = true,
 	GroupWindowsPersist = true,
 	MinimapButton = {
@@ -627,6 +630,7 @@ end
 ---| "DedicatedWindowsPersist"
 ---| "GroupWindows"
 ---| "GroupWindowsNewIndicator"
+---| "GroupWindowsNPCSpeechDetectionNameShown"
 ---| "GroupWindowsUnitPopups"
 ---| "GroupWindowsPersist"
 ---| "MinimapButton"


### PR DESCRIPTION
A setting `GroupWindowsNPCSpeechDetectionNameShown` is added which is false by default, not exposed by now.

Given by using TRP, we also don't show who has 'sent' the message, we'll use this for now and see that people's opinions are regarding that.