### PR TITLE
Set maxLetters = 0 for LinkDialog to force no maximum length

### DIFF
--- a/Modules/Dialogs/LinkDialog.lua
+++ b/Modules/Dialogs/LinkDialog.lua
@@ -55,6 +55,7 @@ StaticPopupDialogs["EAVESDROPPER_LINK_DIALOG"] = {
 	text = ED.Globals.addon_title .. L.POPUP_LINK,
 	button1 = CANCEL,
 	hasEditBox = true,
+	maxLetters = 0,
 	editBoxWidth = 320,
 	OnShow = function(self)
 		local editBox = GetDialogEditBox(self);


### PR DESCRIPTION
Group and Rename Dialog both set a maximum editbox character length of 32.

Opening one of the links in the changelog/about tab in #69 after having opened a Group/Rename dialog would cut off the text at 32 characters as well.

Setting an implicit `maxLetters = 0` for LinkDialogs overrides that behavior and makes the entire url show once more.