### PR TITLE
Ignore line started with [version]

### DIFF
--- a/UI/ChangelogFrame.lua
+++ b/UI/ChangelogFrame.lua
@@ -42,13 +42,14 @@ local function ConvertMarkdownToDataProvider()
 	local urlMatchPattern = "%[([^]]+)%]%(([^%)]+)%)"; -- [text](url) Preserve text only
 	local urlRemovalPattern = "%[[^]]+%]%([^%)]+%)";
 	local gitRefRemovalPattern = "%s*%(%[#.-%([^%)]+%)%s*%)"; -- ([#1](url)) or ([#1](url) and [#2](url)) Remove entirely
+	local versionComparePatter = "^%[[%w%d%.%-]+%]:"; -- Ignore line started with [version]:
 
 	local function ColorizeText(text, color)
 		return "|cn" .. color .. ":" .. text .. "|r";
 	end
 
 	for line in string.gmatch(Changelogs.currentMarkdown, "[^\r\n]*") do
-		if line ~= "" then
+		if line ~= "" and not string.find(line, versionComparePatter) then
 			index = index + 1;
 
 			local tag;

--- a/UI/ChangelogMarkdown.lua
+++ b/UI/ChangelogMarkdown.lua
@@ -93,6 +93,23 @@ Significant feature update introducing Dedicated Windows for unique targets, RP 
 
 ## Full Changelog
 The complete changelog, including older versions, can always be found on [Eavesdropper's GitHub Wiki](https://github.com/Raenore/Eavesdropper/wiki/Full-Changelog).
+
+[unreleased]: https://github.com/Raenore/Eavesdropper/compare/0.4.1...HEAD
+[0.4.1]: https://github.com/Raenore/Eavesdropper/compare/0.4.0...0.4.1
+[0.4.0]: https://github.com/Raenore/Eavesdropper/compare/0.3.0...0.4.0
+[0.3.0]: https://github.com/Raenore/Eavesdropper/compare/0.2.4...0.3.0
+[0.2.4]: https://github.com/Raenore/Eavesdropper/compare/0.2.3...0.2.4
+[0.2.3]: https://github.com/Raenore/Eavesdropper/compare/0.2.2...0.2.3
+[0.2.2]: https://github.com/Raenore/Eavesdropper/compare/0.2.1...0.2.2
+[0.2.1]: https://github.com/Raenore/Eavesdropper/compare/0.2.0...0.2.1
+[0.2.0]: https://github.com/Raenore/Eavesdropper/compare/0.1.5...0.2.0
+[0.1.5]: https://github.com/Raenore/Eavesdropper/compare/0.1.4...0.1.5
+[0.1.4]: https://github.com/Raenore/Eavesdropper/compare/0.1.3...0.1.4
+[0.1.3]: https://github.com/Raenore/Eavesdropper/compare/0.1.2...0.1.3
+[0.1.2]: https://github.com/Raenore/Eavesdropper/compare/0.1.1...0.1.2
+[0.1.1]: https://github.com/Raenore/Eavesdropper/compare/0.1.0...0.1.1
+[0.1.0]: https://github.com/Raenore/Eavesdropper/releases/tag/0.1.0
+
 ]]
 
 ED.Changelogs:SetMarkdown(changelogMarkdown);


### PR DESCRIPTION
In the changelog markdown: Ignore lines that start with [version] so we can easily copy the MD file to the Lua.