### PR TITLE
Improve Multi-Line Editbox Visuals

### DIFF
--- a/UI/SettingsElements.lua
+++ b/UI/SettingsElements.lua
@@ -557,13 +557,17 @@ local function CreateMultiLineEditBox(parent, data)
 	backdrop:SetBackdropBorderColor(0.3, 0.3, 0.3, 1);
 
 
-	local paddingLeft, paddingRight, paddingTop, paddingBottom = 10, 25, 5, 0;
+	local paddingLeft, paddingRight, paddingTop, paddingBottom = 5, 5, 5, 5;
 
 	local scrollFrame = CreateFrame("ScrollFrame", nil, container, "ScrollFrameTemplate");
 	scrollFrame:SetPoint("TOPLEFT", backdrop, "TOPLEFT", paddingLeft, -paddingTop);
 	scrollFrame:SetPoint("BOTTOMRIGHT", backdrop, "BOTTOMRIGHT", -paddingRight, paddingBottom);
-	scrollFrame.ScrollBar:Hide();
 	scrollFrame:EnableMouseWheel(false);
+
+	scrollFrame.ScrollBar:Hide();
+	scrollFrame.ScrollBar:ClearAllPoints();
+	scrollFrame.ScrollBar:SetPoint("TOPRIGHT", scrollFrame, "TOPRIGHT", -6, -3);
+	scrollFrame.ScrollBar:SetPoint("BOTTOMRIGHT", scrollFrame, "BOTTOMRIGHT", -6, 2);
 
 	local editBox = CreateFrame("EditBox", nil, scrollFrame);
 	editBox:SetMultiLine(true);
@@ -571,10 +575,13 @@ local function CreateMultiLineEditBox(parent, data)
 	editBox:SetFontObject("ChatFontNormal");
 	editBox:SetWidth(scrollFrame:GetWidth());
 	editBox:SetHeight(height);
+	local surroundingInset = 4; -- Text inset for left/top/bottom of the EditBox
+	local rightInset = 24; -- Leave room for the ScrollBar on the right
+	editBox:SetTextInsets(surroundingInset, rightInset, surroundingInset, surroundingInset);
 
 	scrollFrame:SetScrollChild(editBox);
 
-	editBox:SetPoint("TOPLEFT", scrollFrame, "TOPLEFT", 0, -5);
+	editBox:SetPoint("TOPLEFT", scrollFrame, "TOPLEFT", 0, 0);
 
 	editBox.settingKey = data.settingKey;
 	editBox.savedThisEdit = false;


### PR DESCRIPTION
Currently, the multi-line editbox text's anchor will act off if the editbox goes to scrollable, then return to non-scrollable: it gets disproportionately closer to the top border.

This PR fixes this issue, and we adjust the scrollbar's position, making it look more balanced. 

It also fixed an issue caused by my mistake, where the bottom of the text could overlap with the bottom border.

</br>
</br>

<img width="844" height="174" alt="MultiLineEditBox1" src="https://github.com/user-attachments/assets/59a718a8-eb50-4615-83d4-68a158d56990" />

</br>
</br>

<img width="844" height="174" alt="MultiLineEditBox2" src="https://github.com/user-attachments/assets/e00de37f-8d85-460a-932a-f3ad40a6ce71" />
