### PR TITLE
Add Utils.CombatLockdown() - checks InCombatLockdown() and PlayerIsInCombat() together

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -605,6 +605,7 @@ stds.wow = {
 		"PanelTemplates_TabResize",
 		"PetCanBeAbandoned",
 		"PlayerHasToy",
+		"PlayerIsInCombat",
 		"PlayMusic",
 		"PlaySound",
 		"PlaySoundFile",

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -265,6 +265,13 @@ function Utils.IsOwnPlayer(sender, event)
 		or (type(sender) == "string" and sender:match("^@.+%-self$"));
 end
 
+---Checks both InCombatLockdown() or PlayerIsInCombat() to determine combat lockdown.
+---There is a potential with bad ping that InCombatLockdown() might not fire in time.
+---@return boolean
+function Utils.CombatLockdown()
+	return InCombatLockdown() or PlayerIsInCombat();
+end
+
 -- ============================================================================
 -- BUILD / VERSION UTILITIES
 -- ============================================================================

--- a/UI/EavesdropperFrame.lua
+++ b/UI/EavesdropperFrame.lua
@@ -175,7 +175,7 @@ end
 
 ---Overrides SharedFrameMixin:HandleVisibility with HideWhenEmpty and WindowVisible logic
 function Eavesdropper_FrameMixin:HandleVisibility()
-	if ED.Database:GetSetting("HideInCombat") and InCombatLockdown() then
+	if ED.Database:GetSetting("HideInCombat") and ED.Utils.CombatLockdown() then
 		self:Hide();
 		return;
 	end
@@ -207,7 +207,7 @@ end
 ---Update the eavesdropped target based on the magnifier, then refresh if needed
 function Eavesdropper_FrameMixin:UpdateTarget()
 	ED.Debug:Print("UpdateTarget");
-	if InCombatLockdown() then return; end
+	if ED.Utils.CombatLockdown() then return; end
 
 	-- Resolve target from magnifier
 	local magnifiedName, magnifiedGUID = ED.Magnifier:GetMagnified();

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -321,7 +321,7 @@ end
 ---Hide in combat when the setting is on; otherwise show the frame.
 ---Overridden by Eavesdropper_FrameMixin for HideWhenEmpty and WindowVisible logic.
 function Eavesdropper_SharedFrameMixin:HandleVisibility()
-	if ED.Database:GetSetting("HideInCombat") and InCombatLockdown() then
+	if ED.Database:GetSetting("HideInCombat") and ED.Utils.CombatLockdown() then
 		self:Hide();
 		return;
 	end

--- a/UI/SettingsFrame.lua
+++ b/UI/SettingsFrame.lua
@@ -567,7 +567,7 @@ function Eavesdropper_SettingsMixin:OnLoad()
 			get = function() return ED.Database:GetSetting("HideInCombat"); end,
 			set = function(val)
 				ED.Database:SetSetting("HideInCombat", val);
-				if InCombatLockdown() then
+				if ED.Utils.CombatLockdown() then
 					ED.Frame:Hide();
 					ED.DedicatedFrame:ForEachFrame(function(frame)
 						frame:Hide();


### PR DESCRIPTION
Information supplied by @Peterodox where a potential bad ping might cause `InCombatLockdown()` checks to not fire reliably to check if combat lockdown is in effect.

`PlayerIsInCombat()` does reliably provide an response though, which is the second check now. Which is rolled into `ED.Utils.CombatLockdown()` to make the check more reliable as a whole.