### PR TITLE
Fix Dedicated Frame (Created by Hotkey) Title Bar Showing Player Original Name Instead of RP Name

### DIFF
--- a/UI/EavesdropperDedicatedFrame.lua
+++ b/UI/EavesdropperDedicatedFrame.lua
@@ -267,6 +267,7 @@ function DedicatedFrame:AddFrameForMagnified()
 		or (magnifiedGUID and canaccessvalue(magnifiedGUID) and ED.PlayerCache:GetSenderDataFromGUID(magnifiedGUID));
 
 	if target then
+		ED.PlayerCache:InsertAndRetrieve(magnifiedName, magnifiedGUID);
 		self:AddFrame(target);
 	end
 end


### PR DESCRIPTION
Currently, if a Dedicated window is created by pressing the newly added hotkey while hovering over another player, the title bar will show that player's original name instead of their RP first name.

For example, this player's original name is Plumleaf, and their RP name is Violet Plumleaf.
Left is the Dedicated window (created by the hotkey); right is the main frame.

<img width="630" height="374" alt="Dedicated99" src="https://github.com/user-attachments/assets/ade206e8-da94-472d-ba4d-f7cb92ce58e2" />


</br></br>

In contrast, adding Dedicated windows from unit popups will prefer using the RP name as the title.

https://github.com/Raenore/Eavesdropper/blob/37a035c7a45b3f9c6fc44be5ed0a0e9ceb31a173/Modules/UnitPopups/UnitPopups.lua#L156-L157