### PR TITLE
Retain Scroll Offset When Chat Update Is Triggered by Tickers

### DIFF
--- a/UI/EavesdropperDedicatedFrame.lua
+++ b/UI/EavesdropperDedicatedFrame.lua
@@ -91,7 +91,7 @@ function Eavesdropper_Dedicated_FrameMixin:OnShow()
 	self:RefreshChat();
 	if not self.chatTicker then
 		self.chatTicker = C_Timer.NewTicker(Constants.CHAT_UPDATE_THROTTLE_DEFAULT, function()
-			self:RefreshChat();
+			self:RefreshChat(true);
 		end);
 	end
 end
@@ -147,10 +147,13 @@ end
 -- ============================================================
 
 ---Repopulate the chat box from stored history
-function Eavesdropper_Dedicated_FrameMixin:RefreshChat()
+---@param retainScroll boolean? If true, retain the previous scroll position.
+function Eavesdropper_Dedicated_FrameMixin:RefreshChat(retainScroll)
 	if not self.ChatBox then return; end
 
 	self.refreshing = true;
+
+	local scrollOffset = self.ChatBox:GetScrollOffset();
 	self.ChatBox:Clear();
 
 	local maxMessages = ED.Database:GetSetting("MaxHistory");
@@ -158,6 +161,10 @@ function Eavesdropper_Dedicated_FrameMixin:RefreshChat()
 
 	if player then
 		self:PopulateHistoryMessages(player, maxMessages);
+	end
+
+	if retainScroll then
+		self.ChatBox:SetScrollOffset(scrollOffset or 0);
 	end
 
 	self:UpdateTitleBar();

--- a/UI/EavesdropperGroupFrame.lua
+++ b/UI/EavesdropperGroupFrame.lua
@@ -109,7 +109,7 @@ function Eavesdropper_Group_FrameMixin:OnShow()
 	self:RefreshChat();
 	if not self.chatTicker then
 		self.chatTicker = C_Timer.NewTicker(Constants.CHAT_UPDATE_THROTTLE_DEFAULT, function()
-			self:RefreshChat();
+			self:RefreshChat(true);
 		end);
 	end
 end
@@ -162,16 +162,23 @@ end
 -- ============================================================
 
 ---Repopulate the chat box by merging history from all tracked players
-function Eavesdropper_Group_FrameMixin:RefreshChat()
+---@param retainScroll boolean? If true, retain the previous scroll position.
+function Eavesdropper_Group_FrameMixin:RefreshChat(retainScroll)
 	if not self.ChatBox then return; end
 
 	self.refreshing = true;
+
+	local scrollOffset = self.ChatBox:GetScrollOffset();
 	self.ChatBox:Clear();
 
 	local maxMessages = ED.Database:GetSetting("MaxHistory");
 
 	if self.players and #self.players > 0 then
 		self:PopulateGroupHistoryMessages(maxMessages);
+	end
+
+	if retainScroll then
+		self.ChatBox:SetScrollOffset(scrollOffset or 0);
 	end
 
 	self.refreshing = false;


### PR DESCRIPTION
The following discussions and proposed changes are limited to Dedicated and Group frames.

A user reported that when they scrolled up to view older messages, the window would scroll to the bottom on its own every few seconds, which isn't ideal because they were still reading.

This is because `chatTicker` calls `Frame:RefreshChat()` every 10 seconds, in which [ChatBox:Clear()](https://www.townlong-yak.com/framexml/latest/Blizzard_SharedXML/ScrollingMessageFrame.lua#292) resets the offset to 0.

With this PR,  if `Frame:RefreshChat()` is triggered by the ticker, the window should retain the scroll offset.

---
PS: I didn't use this method, which prevents the window from updating, because we still want stuff like message timestamps to get updated.
https://github.com/Raenore/Eavesdropper/blob/3a9e1c64235eddab7e0976daa645f689e605bbd1/UI/EavesdropperFrame.lua#L246

---
Potential future improvement: Adding a visual cue to the "Scroll to Bottom" button when the window receives a new message while the scroll is not at the bottom.