### PR TITLE
Screenshot Helper

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -412,6 +412,7 @@ stds.wow = {
 
 		Menu = {
 			fields = {
+				"GetManager",
 				"ModifyMenu",
 			},
 		},

--- a/Eavesdropper.toc
+++ b/Eavesdropper.toc
@@ -101,6 +101,7 @@ UI\ChangelogMarkdown.lua
 UI\SettingsElements.lua
 UI\SettingsFrame.lua
 UI\SettingsFrame.xml
+UI\ScreenshotHelper.lua
 
 Deprecated.lua
 Eavesdropper.lua

--- a/UI/EavesdropperFrame.lua
+++ b/UI/EavesdropperFrame.lua
@@ -77,8 +77,10 @@ function Eavesdropper_FrameMixin:OnLoad()
 	end);
 end
 
--- Unnecessary, for now.
 function Eavesdropper_FrameMixin:OnHide()
+	if self.alphaChannelMode and self.SetAlphaChannelMode then
+		self:SetAlphaChannelMode(nil);
+	end
 end
 
 -- ============================================================

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -82,6 +82,10 @@ function Eavesdropper_SharedFrameMixin:OnHideInstanceFrame()
 	if frameName and _G[frameName] == self then
 		_G[frameName] = nil;
 	end
+
+	if self.alphaChannelMode and self.SetAlphaChannelMode then
+		self:SetAlphaChannelMode(nil);
+	end
 end
 
 ---Override in concrete mixins to remove self from the owning frame-manager table.
@@ -485,4 +489,30 @@ function Eavesdropper_SharedFrameMixin:TryAddMessage(entry)
 	end
 
 	self:AddMessage(entry);
+end
+
+-- ============================================================
+-- Screenshot Helper
+-- ============================================================
+
+function Eavesdropper_SharedFrameMixin:SetAlphaChannelMode(mode)
+	-- mode 1: All Widgets turn black + white fullscreen backdrop
+	-- mode 2: Widgets use original colors + black fullscreen backdrop
+	-- other : Disable
+
+	self.alphaChannelMode = mode;
+
+	local frameStrata;
+
+	ED.ScreenshotHelper.SetupObjectColorByMode(self, mode);
+
+	if mode == 1 or mode == 2 then
+		frameStrata = "MEDIUM";
+		self:Raise();
+	else
+		frameStrata = "BACKGROUND";
+		self:ApplyThemeColors();
+	end
+
+	self:SetFrameStrata(frameStrata);
 end

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -500,6 +500,9 @@ function Eavesdropper_SharedFrameMixin:SetAlphaChannelMode(mode)
 	-- mode 2: Widgets use original colors + black fullscreen backdrop
 	-- other : Disable
 
+	-- Nothing to restore if this frame was never colorized
+	if not mode and not self.alphaChannelMode then return; end
+
 	self.alphaChannelMode = mode;
 
 	local frameStrata;

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -142,6 +142,18 @@ function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
 		local openMenu = Menu.GetManager():GetOpenMenu();
 		if openMenu then
 			ED.ScreenshotHelper.SetupObjectColorByMode(openMenu, alphaChannelMode);
+
+			-- To modify submenu, hover the cursor over a button on the submenu then call this function again
+			local foci = GetMouseFoci();
+			if foci and foci[1] then
+				local objectParent = foci[1]:GetParent();
+				if objectParent and objectParent.GetPoint then
+					local _, relativeTo = objectParent:GetPoint(1);
+					if relativeTo and relativeTo.GetParent and relativeTo:GetParent() == openMenu then
+						ED.ScreenshotHelper.SetupObjectColorByMode(objectParent, alphaChannelMode);
+					end
+				end
+			end
 		end
 	end
 end

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -67,4 +67,29 @@ function ScreenshotHelper.SetupObjectColorByMode(object, alphaChannelMode)
 	ScreenshotHelper.SetupObjectColor(object, colorize, colorValue);
 end
 
+function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
+	if not ED.SettingsFrame then
+		ED.Settings:Init();
+	end
+
+	ED.SettingsFrame:Show();
+	ED.SettingsFrame:SetAlphaChannelMode(alphaChannelMode);
+
+	if ED.Frame:IsVisible() then
+		ED.Frame:SetAlphaChannelMode(alphaChannelMode);
+	end
+
+	ED.DedicatedFrame:ForEachFrame(function(frame)
+		if frame:IsVisible() then
+			frame:SetAlphaChannelMode(alphaChannelMode);
+		end
+	end);
+
+	ED.GroupFrame:ForEachFrame(function(frame)
+		if frame:IsVisible() then
+			frame:SetAlphaChannelMode(alphaChannelMode);
+		end
+	end);
+end
+
 ED.ScreenshotHelper = ScreenshotHelper;

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -1,0 +1,70 @@
+-- Copyright The Eavesdropper Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+---@class EavesdropperScreenshotHelper
+local ScreenshotHelper = {};
+
+---Colorize an object and all their children
+---@param object any
+---@param colorize boolean
+---@param colorValue number
+function ScreenshotHelper.SetupObjectColor(object, colorize, colorValue)
+	if object:IsObjectType("FontString") then
+		if colorize then
+			if not object.originalColor then
+				local r, g, b = object:GetTextColor();
+				object.originalColor = {r = r, g = g, b = b};
+			end
+			object:SetTextColor(colorValue, colorValue, colorValue);
+			object:SetFixedColor(true);
+		else
+			if object.originalColor then
+				local color = object.originalColor;
+				object:SetTextColor(color.r, color.g, color.b);
+				object.originalColor = nil;
+			end
+			object:SetFixedColor(false);
+		end
+	elseif object:IsObjectType("Texture") then
+		if colorize then
+			if not object.originalColor then
+				local r, g, b = object:GetVertexColor();
+				object.originalColor = {r = r, g = g, b = b};
+			end
+			object:SetVertexColor(colorValue, colorValue, colorValue);
+		else
+			if object.originalColor then
+				local color = object.originalColor;
+				object:SetVertexColor(color.r, color.g, color.b);
+				object.originalColor = nil;
+			end
+		end
+	end
+
+	if object.GetRegions then
+		for _, region in ipairs({object:GetRegions()}) do
+			ScreenshotHelper.SetupObjectColor(region, colorize, colorValue);
+		end
+	end
+
+	if object.GetChildren then
+		for _, child in ipairs({object:GetChildren()}) do
+			ScreenshotHelper.SetupObjectColor(child, colorize, colorValue);
+		end
+	end
+end
+
+---Colorize an object by alphaChannelMode
+---@param object any
+---@param alphaChannelMode number|nil
+function ScreenshotHelper.SetupObjectColorByMode(object, alphaChannelMode)
+	-- mode 1: All Widgets turn black + white fullscreen backdrop
+	-- mode 2: Widgets use original colors + black fullscreen backdrop
+	-- other : Disable
+
+	local colorize = alphaChannelMode == 1;
+	local colorValue = alphaChannelMode == 1 and 0 or 1;
+	ScreenshotHelper.SetupObjectColor(object, colorize, colorValue);
+end
+
+ED.ScreenshotHelper = ScreenshotHelper;

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -17,7 +17,8 @@ function ScreenshotHelper.SetupObjectColor(object, colorize, colorValue)
 
 			local sequence = string.match(text, "|A:([^|]+)|a");
 			while sequence do
-				local atlas, height, width, offsetX, offsetY, r, g, b = string.split(":", sequence);
+				local atlas, height, width, offsetX, offsetY = string.split(":", sequence);
+				local r, g, b;
 				if colorize then
 					local vertexColor = math.floor(colorValue * 255);
 					r, g, b = vertexColor, vertexColor, vertexColor;
@@ -32,7 +33,8 @@ function ScreenshotHelper.SetupObjectColor(object, colorize, colorValue)
 
 			sequence = string.match(text, "|T([^|]+)|t");
 			while sequence do
-				local path, height, width, offsetX, offsetY, textureWidth, textureHeight, leftTexel, rightTexel, topTexel, bottomTexel, r, g, b = string.split(":", sequence);
+				local path, height, width, offsetX, offsetY, textureWidth, textureHeight, leftTexel, rightTexel, topTexel, bottomTexel = string.split(":", sequence);
+				local r, g, b;
 				if colorize then
 					local vertexColor = math.floor(colorValue * 255);
 					r, g, b = vertexColor, vertexColor, vertexColor;

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -67,9 +67,6 @@ function ScreenshotHelper.SetupObjectColorByMode(object, alphaChannelMode)
 	ScreenshotHelper.SetupObjectColor(object, colorize, colorValue);
 end
 
----Store all Menu (dropdown, context) overlays
-local MenuOverlayFrames = {};
-
 function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
 	if not ED.SettingsFrame then
 		ED.Settings:Init();
@@ -98,55 +95,10 @@ function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
 		ED.ScreenshotHelper.SetupObjectColorByMode(GameTooltip, alphaChannelMode);
 	end
 
-	-- Modify Context Menu
-	if alphaChannelMode == 1 then
-		local OverrideMenuStyleMixin = CreateFromMixins(MenuStyle1Mixin);
-
-		function OverrideMenuStyleMixin:Generate()
-			local background = self:AttachTexture();
-			background:SetAtlas("common-dropdown-bg");
-
-			local x, y = 10, 3;
-			background:SetPoint("TOPLEFT", -x, y);
-			background:SetPoint("BOTTOMRIGHT", x, -y);
-			background:SetAlpha(.925);
-
-			local menu = background:GetParent();
-			if not menu.OverlayFrame then
-				local overlay = CreateFrame("Frame", nil, menu);
-				MenuOverlayFrames[overlay] = true;
-				menu.OverlayFrame = overlay;
-				overlay:SetAllPoints(true);
-				overlay.Background = overlay:CreateTexture(nil, "OVERLAY");
-				overlay.Background:SetAtlas("common-dropdown-bg");
-				overlay.Background:SetPoint("TOPLEFT", -x, y);
-				overlay.Background:SetPoint("BOTTOMRIGHT", x, -y);
-				overlay.Background:SetVertexColor(0, 0, 0);
-				overlay:SetScript("OnHide", function()
-					overlay:Hide();
-				end);
-			end
-			menu.OverlayFrame.MenuBackground = background;
-		end
-
-		MenuVariants.GetDefaultContextMenuMixin = function()
-			return OverrideMenuStyleMixin;
-		end
-
-		for overlay in pairs(MenuOverlayFrames) do
-			overlay:Show();
-			overlay:SetFrameStrata("TOOLTIP");
-			overlay:SetFrameLevel(10000);
-			overlay.MenuBackground:Hide();
-		end
-	else
-		MenuVariants.GetDefaultContextMenuMixin = function()
-			return MenuStyle1Mixin;
-		end
-
-		for overlay in pairs(MenuOverlayFrames) do
-			overlay:Hide();
-			overlay.MenuBackground:Show();
+	if Menu.GetManager():IsAnyMenuOpen() then
+		local openMenu = Menu.GetManager():GetOpenMenu();
+		if openMenu then
+			ED.ScreenshotHelper.SetupObjectColorByMode(openMenu, alphaChannelMode);
 		end
 	end
 end

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -115,22 +115,32 @@ function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
 		ED.Settings:Init();
 	end
 
-	ED.SettingsFrame:Show();
-	ED.SettingsFrame:SetAlphaChannelMode(alphaChannelMode);
+	if ED.SettingsFrame then
+		if alphaChannelMode then
+			ED.SettingsFrame:Show();
+		end
+		ED.SettingsFrame:SetAlphaChannelMode(alphaChannelMode);
+	end
 
 	if ED.Frame:IsVisible() then
 		ED.Frame:SetAlphaChannelMode(alphaChannelMode);
+	else
+		ED.Frame:SetAlphaChannelMode(nil);
 	end
 
 	ED.DedicatedFrame:ForEachFrame(function(frame)
 		if frame:IsVisible() then
 			frame:SetAlphaChannelMode(alphaChannelMode);
+		else
+			frame:SetAlphaChannelMode(nil);
 		end
 	end);
 
 	ED.GroupFrame:ForEachFrame(function(frame)
 		if frame:IsVisible() then
 			frame:SetAlphaChannelMode(alphaChannelMode);
+		else
+			frame:SetAlphaChannelMode(nil);
 		end
 	end);
 

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -10,6 +10,49 @@ local ScreenshotHelper = {};
 ---@param colorValue number
 function ScreenshotHelper.SetupObjectColor(object, colorize, colorValue)
 	if object:IsObjectType("FontString") then
+		local text = object:GetText();
+		if text then
+			-- Change the vertex color for Texture/Atlas escape sequences
+			local textureFound;
+
+			local sequence = string.match(text, "|A:([^|]+)|a");
+			while sequence do
+				local atlas, height, width, offsetX, offsetY, r, g, b = string.split(":", sequence);
+				if colorize then
+					local vertexColor = math.floor(colorValue * 255);
+					r, g, b = vertexColor, vertexColor, vertexColor;
+				else
+					r, g, b = 255, 255, 255;
+				end
+				sequence = string.gsub(sequence, "%-", "%%-");
+				text = string.gsub(text, "|A:"..sequence.."|a", string.format("|AA:%s:%s:%s:%s:%s:%s:%s:%s|a", atlas, height or 0, width or 0, offsetX or 0, offsetY or 0, r or 255, g or 255, b or 255), 1);
+				sequence = string.match(text, "|A:([^|]+)|a");
+				textureFound = true;
+			end
+
+			sequence = string.match(text, "|T([^|]+)|t");
+			while sequence do
+				local path, height, width, offsetX, offsetY, textureWidth, textureHeight, leftTexel, rightTexel, topTexel, bottomTexel, r, g, b = string.split(":", sequence);
+				if colorize then
+					local vertexColor = math.floor(colorValue * 255);
+					r, g, b = vertexColor, vertexColor, vertexColor;
+				else
+					r, g, b = 255, 255, 255;
+				end
+				sequence = string.gsub(sequence, "%-", "%%-");
+				text = string.gsub(text, "|T"..sequence.."|t", string.format("|Z%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s|z", path, height or 0, width or 0, offsetX or 0, offsetY or 0, textureWidth or 16, textureHeight or 16, leftTexel or 0, rightTexel or 16, topTexel or 0, bottomTexel or 16, r or 255, g or 255, b or 255), 1);
+				sequence = string.match(text, "|T([^|]+)|t");
+				textureFound = true;
+			end
+
+			if textureFound then
+				text = string.gsub(text, "|AA", "|A");
+				text = string.gsub(text, "|Z", "|T");
+				text = string.gsub(text, "|z", "|t");
+				object:SetText(text);
+			end
+		end
+
 		if colorize then
 			if not object.originalColor then
 				local r, g, b = object:GetTextColor();

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -67,6 +67,9 @@ function ScreenshotHelper.SetupObjectColorByMode(object, alphaChannelMode)
 	ScreenshotHelper.SetupObjectColor(object, colorize, colorValue);
 end
 
+---Store all Menu (dropdown, context) overlays
+local MenuOverlayFrames = {};
+
 function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
 	if not ED.SettingsFrame then
 		ED.Settings:Init();
@@ -90,6 +93,62 @@ function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
 			frame:SetAlphaChannelMode(alphaChannelMode);
 		end
 	end);
+
+	if GameTooltip:IsVisible() then
+		ED.ScreenshotHelper.SetupObjectColorByMode(GameTooltip, alphaChannelMode);
+	end
+
+	-- Modify Context Menu
+	if alphaChannelMode == 1 then
+		local OverrideMenuStyleMixin = CreateFromMixins(MenuStyle1Mixin);
+
+		function OverrideMenuStyleMixin:Generate()
+			local background = self:AttachTexture();
+			background:SetAtlas("common-dropdown-bg");
+
+			local x, y = 10, 3;
+			background:SetPoint("TOPLEFT", -x, y);
+			background:SetPoint("BOTTOMRIGHT", x, -y);
+			background:SetAlpha(.925);
+
+			local menu = background:GetParent();
+			if not menu.OverlayFrame then
+				local overlay = CreateFrame("Frame", nil, menu);
+				MenuOverlayFrames[overlay] = true;
+				menu.OverlayFrame = overlay;
+				overlay:SetAllPoints(true);
+				overlay.Background = overlay:CreateTexture(nil, "OVERLAY");
+				overlay.Background:SetAtlas("common-dropdown-bg");
+				overlay.Background:SetPoint("TOPLEFT", -x, y);
+				overlay.Background:SetPoint("BOTTOMRIGHT", x, -y);
+				overlay.Background:SetVertexColor(0, 0, 0);
+				overlay:SetScript("OnHide", function()
+					overlay:Hide();
+				end);
+			end
+			menu.OverlayFrame.MenuBackground = background;
+		end
+
+		MenuVariants.GetDefaultContextMenuMixin = function()
+			return OverrideMenuStyleMixin;
+		end
+
+		for overlay in pairs(MenuOverlayFrames) do
+			overlay:Show();
+			overlay:SetFrameStrata("TOOLTIP");
+			overlay:SetFrameLevel(10000);
+			overlay.MenuBackground:Hide();
+		end
+	else
+		MenuVariants.GetDefaultContextMenuMixin = function()
+			return MenuStyle1Mixin;
+		end
+
+		for overlay in pairs(MenuOverlayFrames) do
+			overlay:Hide();
+			overlay.MenuBackground:Show();
+		end
+	end
 end
 
 ED.ScreenshotHelper = ScreenshotHelper;

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -110,6 +110,9 @@ function ScreenshotHelper.SetupObjectColorByMode(object, alphaChannelMode)
 	ScreenshotHelper.SetupObjectColor(object, colorize, colorValue);
 end
 
+---Store all Menu (dropdown, context) overlays
+local MenuOverlayFrames = {};
+
 function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
 	if not ED.SettingsFrame then
 		ED.Settings:Init();

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -110,9 +110,6 @@ function ScreenshotHelper.SetupObjectColorByMode(object, alphaChannelMode)
 	ScreenshotHelper.SetupObjectColor(object, colorize, colorValue);
 end
 
----Store all Menu (dropdown, context) overlays
-local MenuOverlayFrames = {};
-
 function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
 	if not ED.SettingsFrame then
 		ED.Settings:Init();

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -1,5 +1,5 @@
 -- Copyright The Eavesdropper Authors
--- SPDX-License-Identifier: Apache-2.0
+-- SPDX-License-Identifier: GPL-3.0-or-later
 
 ---@class EavesdropperScreenshotHelper
 local ScreenshotHelper = {};

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -4,6 +4,14 @@
 ---@class EavesdropperScreenshotHelper
 local ScreenshotHelper = {};
 
+---Frames rendering above the fullscreen backdrop, which have to be hidden manually
+local externalFrames = {
+	"PTR_IssueReporter",
+};
+
+---Frames hidden on entering a mode, restored when it is exited
+local hiddenFrames = {};
+
 ---Colorize an object and all their children
 ---@param object any
 ---@param colorize boolean
@@ -112,7 +120,28 @@ function ScreenshotHelper.SetupObjectColorByMode(object, alphaChannelMode)
 	ScreenshotHelper.SetupObjectColor(object, colorize, colorValue);
 end
 
+---Hide frames the fullscreen backdrop cannot cover, or restore the ones we hid
+---@param hide boolean
+function ScreenshotHelper.SetExternalFramesHidden(hide)
+	if hide then
+		for _, frameName in ipairs(externalFrames) do
+			local frame = _G[frameName];
+			if frame and frame.IsShown and frame:IsShown() then
+				hiddenFrames[#hiddenFrames + 1] = frame;
+				frame:Hide();
+			end
+		end
+	else
+		for _, frame in ipairs(hiddenFrames) do
+			frame:Show();
+		end
+		wipe(hiddenFrames);
+	end
+end
+
 function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
+	ScreenshotHelper.SetExternalFramesHidden(alphaChannelMode == 1 or alphaChannelMode == 2);
+
 	if not ED.SettingsFrame then
 		ED.Settings:Init();
 	end

--- a/UI/SettingsFrame.lua
+++ b/UI/SettingsFrame.lua
@@ -1372,7 +1372,7 @@ function Eavesdropper_SettingsMixin:OnHide()
 	ED.Frame.settingsOpened = false;
 	ED.Frame:HandleVisibility();
 
-	if self.SetAlphaChannelMode then
+	if self.alphaChannelMode and self.SetAlphaChannelMode then
 		self:SetAlphaChannelMode(nil);
 	end
 end
@@ -1385,6 +1385,8 @@ function Eavesdropper_SettingsMixin:SetAlphaChannelMode(mode)
 	-- mode 1: All Widgets turn black + white fullscreen backdrop
 	-- mode 2: Widgets use original colors + black fullscreen backdrop
 	-- other : Disable
+
+	self.alphaChannelMode = mode;
 
 	local showFullScreenBackdrop = mode == 1 or mode == 2;
 	local enableColorizing = mode == 1;

--- a/UI/SettingsFrame.lua
+++ b/UI/SettingsFrame.lua
@@ -1392,7 +1392,6 @@ function Eavesdropper_SettingsMixin:SetAlphaChannelMode(mode)
 	local colorize = mode == 1;
 
 	ED.ScreenshotHelper.SetupObjectColorByMode(self, mode);
-	ED.ScreenshotHelper.SetupObjectColorByMode(GameTooltip, mode);
 
 	self.Background.BackgroundColor:SetVertexColor(1, 1, 1);
 

--- a/UI/SettingsFrame.lua
+++ b/UI/SettingsFrame.lua
@@ -1373,7 +1373,7 @@ function Eavesdropper_SettingsMixin:OnHide()
 	ED.Frame:HandleVisibility();
 
 	if self.alphaChannelMode and self.SetAlphaChannelMode then
-		self:SetAlphaChannelMode(nil);
+		ED.ScreenshotHelper.SetAlphaChannelMode(nil);
 	end
 end
 

--- a/UI/SettingsFrame.lua
+++ b/UI/SettingsFrame.lua
@@ -1389,61 +1389,14 @@ function Eavesdropper_SettingsMixin:SetAlphaChannelMode(mode)
 	self.alphaChannelMode = mode;
 
 	local showFullScreenBackdrop = mode == 1 or mode == 2;
-	local enableColorizing = mode == 1;
-	local a = mode == 1 and 0 or 1;
+	local colorize = mode == 1;
 
-	local function SetupFunc(object)
-		if object:IsObjectType("FontString") then
-			if enableColorizing then
-				if not object.originalColor then
-					local r, g, b = object:GetTextColor();
-					object.originalColor = {r = r, g = g, b = b};
-				end
-				object:SetTextColor(a, a, a);
-				object:SetFixedColor(true);
-			else
-				if object.originalColor then
-					local color = object.originalColor;
-					object:SetTextColor(color.r, color.g, color.b);
-					object.originalColor = nil;
-				end
-				object:SetFixedColor(false);
-			end
-		elseif object:IsObjectType("Texture") then
-			if enableColorizing then
-				if not object.originalColor then
-					local r, g, b = object:GetVertexColor();
-					object.originalColor = {r = r, g = g, b = b};
-				end
-				object:SetVertexColor(a, a, a);
-			else
-				if object.originalColor then
-					local color = object.originalColor;
-					object:SetVertexColor(color.r, color.g, color.b);
-					object.originalColor = nil;
-				end
-			end
-		end
-
-		if object.GetRegions then
-			for _, region in ipairs({object:GetRegions()}) do
-				SetupFunc(region);
-			end
-		end
-
-		if object.GetChildren then
-			for _, child in ipairs({object:GetChildren()}) do
-				SetupFunc(child);
-			end
-		end
-	end
-
-	SetupFunc(self);
-	SetupFunc(GameTooltip);
+	ED.ScreenshotHelper.SetupObjectColorByMode(self, mode);
+	ED.ScreenshotHelper.SetupObjectColorByMode(GameTooltip, mode);
 
 	self.Background.BackgroundColor:SetVertexColor(1, 1, 1);
 
-	if enableColorizing then
+	if colorize then
 		self.NineSlice.Text:SetText(nil);
 	else
 		self.NineSlice.Text:SetText(ED.Globals.addon_settings_icon .. " " .. ED.Globals.addon_title .. " " .. SETTINGS);


### PR DESCRIPTION
Screenshot Helper makes creating feature previews easier.

## Support More Frames
Our current screenshot helper supports the SettingsFrame and GameTooltip. This PR will expand it to:
- All ED Chat History Windows: Main Frame, Dedicated, and Group.
- Blizzard Menu and its submenu.

## Commands Change
Changed the command to `/run ED.ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)`
- `/run ED.ScreenshotHelper.SetAlphaChannelMode(1)`   This makes every widget black while preserving its transparency and displays a white full-screen backdrop.
- `/run ED.ScreenshotHelper.SetAlphaChannelMode(2)`   This should restore all widget colors and show a black full-screen backdrop.
- `/run ED.ScreenshotHelper.SetAlphaChannelMode()`   Exit screenshot mode.

## The Limitations
- The full-screen backdrop is created on the SettingsFrame, so when making previews for other ED frames, we still need to keep the SettingsFrame visible.
- Chat text colors will be restored to their original values when the message updates.
- To colorize a submenu, we must move the cursor onto it before using the command.
<img width="976" height="434" alt="WoWScrnShot_063026_212043" src="https://github.com/user-attachments/assets/df33addf-47e3-4828-a053-666871f25215" />
