### PR TITLE
Collect issues (luacheck & editorconfig) together before marking job as failed

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,19 +21,30 @@ jobs:
           submodules: recursive
 
       - name: Run Luacheck
+        id: luacheck
         if: contains(github.event.pull_request.labels.*.name, 'documentation') == false
         uses: nebularg/actions-luacheck@v1
+        continue-on-error: true
         with:
           args: --no-color -q
           files: $(git ls-files '*.lua' ':!:Locales/????.lua')
           annotate: warning
 
       - name: Run editorconfig-checker
+        id: editorconfig
         if: contains(github.event.pull_request.labels.*.name, 'documentation') == false
         uses: wow-rp-addons/actions-editorconfig-check@v1.0.2
+        continue-on-error: true
         with:
           args: -no-color
           files: $(git ls-files '*.lua' '*.sh' '*.xml' ':!:Locales/*.lua' ':!:UI/ChangelogMarkdown.lua')
+
+      - name: Check lint results
+        if: steps.luacheck.outcome == 'failure' || steps.editorconfig.outcome == 'failure'
+        run: |
+          echo "Luacheck: ${{ steps.luacheck.outcome }}"
+          echo "editorconfig-checker: ${{ steps.editorconfig.outcome }}"
+          exit 1
 
       - name: Create Package
         uses: BigWigsMods/packager@v2


### PR DESCRIPTION
Note: This will mean that even on failures in luacheck or editorconfig that -that- specific step is marked as 'success' (green) even if there's issues found. The 'fail' (red) check now happens at the "Check lint results" step instead.

The main thing is that the build shows it failed, and that we collect all issues together instead of having multiple failure pushes because one step blocked the other.

As soon as this is merged, all -future- PR jobs will run with these settings.
For current PRs they will probably have to be rebased on main so they have the proper job files.