### PR TITLE
Optimize performance in various locations

### DIFF
--- a/Core/ChatFormatter.lua
+++ b/Core/ChatFormatter.lua
@@ -407,7 +407,7 @@ function ChatFormatter:FormatMessage(entry, forGroup, forceDisplayMode)
 	local age = now - (entry.t or now);
 	local timestamp;
 
-	if age < 30 * 60 then
+	if age < ED.Constants.TIMESTAMP_FREEZE_AGE then
 		timestamp = age < 60 and "<1m" or string.format("%sm", math.floor(age / 60));
 	else
 		timestamp = date("%H:%M", entry.t);

--- a/Core/ChatHistory.lua
+++ b/Core/ChatHistory.lua
@@ -18,12 +18,16 @@
 ---@field list table<number, EavesdropperChatEntry> Global index of entries by ID
 ---@field minEntryId number
 ---@field nextEntryId number
----@field deduper table<string, number> Deduplication timestamps
+---@field deduper table<string, number> Deduplication timestamps, current generation
+---@field deduperPrevious table<string, number> Deduplication timestamps, previous generation
+---@field deduperRotatedAt number GetTime() the current generation began
 ---@field byTime table<number, EavesdropperChatEntry> Legacy migration index keyed by timestamp
 local ChatHistory = {};
 
 ChatHistory.byTime = {};
 ChatHistory.deduper = {};
+ChatHistory.deduperPrevious = {};
+ChatHistory.deduperRotatedAt = 0;
 ChatHistory.minEntryId = 0;
 ChatHistory.history = {};
 ChatHistory.list = {};
@@ -134,6 +138,8 @@ function ChatHistory:LoadFromSaved(savedHistory)
 	self.history = savedHistory or {};
 	self.list = {};
 	self.deduper = {};
+	self.deduperPrevious = {};
+	self.deduperRotatedAt = 0;
 	self.byTime = self.byTime or {};
 
 	local now = time();
@@ -174,7 +180,9 @@ function ChatHistory:GetPlayerHistory(player, maxEntries, frame)
 	return entries;
 end
 
----Checks if a chat message is a duplicate
+---Checks if a chat message is a duplicate.
+---Keeps two generations instead of one, so a key survives a full window even if it was
+---written right before a rotation.
 ---@param event string Event name
 ---@param sender string Sender name
 ---@param message string Message content
@@ -184,6 +192,14 @@ end
 ---@return boolean True if duplicate, false otherwise
 function ChatHistory:IsDuplicate(event, sender, message, channel, language, guid)
 	local now = GetTime();
+	local window = Constants.CHAT_HISTORY.DUPLICATE_WINDOW;
+
+	if now - self.deduperRotatedAt >= window then
+		self.deduperPrevious = self.deduper;
+		self.deduper = {};
+		self.deduperRotatedAt = now;
+	end
+
 	local key =
 		(event or "") .. "|" ..
 		(sender or "") .. "|" ..
@@ -192,8 +208,8 @@ function ChatHistory:IsDuplicate(event, sender, message, channel, language, guid
 		(language or "") .. "|" ..
 		(guid or "");
 
-	local last = self.deduper[key];
-	if last and now - last < 0.5 then
+	local last = self.deduper[key] or self.deduperPrevious[key];
+	if last and now - last < window then
 		return true;
 	end
 

--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -98,11 +98,16 @@ Constants.CHAT_EVENTS_ADVANCED_FORMATTING = {
 
 ---Configuration constants for the chat history system.
 ---@class EavesdropperChatHistoryConstants
+---@field DUPLICATE_WINDOW number
 ---@field EXPIRE_AFTER number
 ---@field IGNORE_EMOTES string[]
 Constants.CHAT_HISTORY = {
 	---Entries older than this many seconds are pruned on load (30 minutes).
 	EXPIRE_AFTER = 60 * 30,
+
+	---Seconds within which an identical message counts as a duplicate.
+	---Doubles as the rotation period of the dedupe generations in ChatHistory.IsDuplicate.
+	DUPLICATE_WINDOW = 0.5,
 
 	---Emote substrings that mention "you" but should not trigger notifications.
 	---@type string[]

--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -156,6 +156,10 @@ Constants.TIMESTAMP_FREEZE_AGE = 30 * 60;
 ---@type number
 Constants.TARGET_UPDATE_THROTTLE = 1;
 
+---Seconds a burst of MSP invalidations collapses into a single redraw.
+---@type number
+Constants.DATA_REFRESH_THROTTLE = 5;
+
 -- Credits: Listener by tmgpub.
 ---@type table<string, boolean>
 local commonTitles = {

--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -408,8 +408,9 @@ Constants.MESSAGE_PREFIXES = {
 ---@class EavesdropperMSPConstants
 ---@field CACHE_RESET_TIME number
 Constants.MSP = {
-	---Seconds before a cached MSP result is considered stale.
-	CACHE_RESET_TIME = 5,
+	---Max time for the MSP cache, in seconds. Invalidation is event-driven; this only catches an
+	---update we were never told about. Set to 0 to disable.
+	CACHE_RESET_TIME = 300,
 };
 
 ---MSP fields that are relevant to name/colour resolution.

--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -142,9 +142,19 @@ Constants.CHAT_HISTORY = {
 ---@type number
 Constants.CHAT_NEW_INDICATOR_FADE_OUT = 10;
 
----Default chat refresh throttle interval in milliseconds.
+---Seconds between the periodic redraws that age message timestamps.
 ---@type number
-Constants.CHAT_UPDATE_THROTTLE_DEFAULT = 10;
+Constants.WINDOW_REFRESH_INTERVAL = 60;
+
+---Age in seconds at which a message stops changing appearance entirely.
+---Shared by ChatFormatter:FormatMessage and the refresh ticker; they must not drift apart.
+---@type number
+Constants.TIMESTAMP_FREEZE_AGE = 30 * 60;
+
+---Seconds UpdateTarget skips a repeat refresh of the same target.
+---A debounce, not a refresh timer; keep below WINDOW_REFRESH_INTERVAL or it swallows ticker refreshes.
+---@type number
+Constants.TARGET_UPDATE_THROTTLE = 1;
 
 -- Credits: Listener by tmgpub.
 ---@type table<string, boolean>

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -37,6 +37,7 @@ local Database = {};
 ---@field MinimapButton EavesdropperGlobalMinimapButton?
 ---@field SettingsWindowPosition EavesdropperWindowPosition?
 ---@field GroupWindowsNPCSpeechDetectionNameShown boolean?
+---@field WindowNewIndicator boolean?
 ---@field WelcomeMessage boolean?
 
 ---@type EavesdropperGlobal
@@ -60,6 +61,7 @@ local GLOBAL_DEFAULTS = {
 		ShowAddonCompartmentButton = true,
 	},
 	SettingsWindowPosition = ED.Utils.ShallowCopy(Constants.DEFAULT_WINDOW_POSITION),
+	WindowNewIndicator = true,
 	WelcomeMessage = true,
 };
 
@@ -730,6 +732,7 @@ end
 ---| "GroupWindowsPersist"
 ---| "MinimapButton"
 ---| "SettingsWindowPosition"
+---| "WindowNewIndicator"
 ---| "WelcomeMessage"
 
 ---Returns the effective value of a global setting.

--- a/Core/MSPHandler.lua
+++ b/Core/MSPHandler.lua
@@ -30,11 +30,14 @@ local function WipeCache()
 end
 
 ---Invalidates the MSP cache; the next TryGetMSPData call drops every cached player.
+---Also schedules a redraw through the burst window, so the updated data is drawn.
 function MSP.InvalidateCache()
 	invalidateCache = true;
+	Eavesdropper_SharedFrameMixin.ScheduleDataRefresh();
 end
 
 ---Drops a single player, leaving every other cached player intact.
+---Also schedules a redraw through the burst window, so the updated data is drawn.
 ---@param playerName string
 function MSP.InvalidatePlayer(playerName)
 	local key = ED.Utils.AddRealmSuffix(playerName);
@@ -43,6 +46,7 @@ function MSP.InvalidatePlayer(playerName)
 
 	MSP.cache[guid] = nil;
 	cacheNames[key] = nil;
+	Eavesdropper_SharedFrameMixin.ScheduleDataRefresh();
 end
 
 ---True once TRP3 has fired WORKFLOW_ON_LOADED. TRP3_API existing does not mean it is ready

--- a/Core/MSPHandler.lua
+++ b/Core/MSPHandler.lua
@@ -7,11 +7,21 @@ local Constants = ED.Constants;
 ---@class EavesdropperMSP
 local MSP = {};
 
-MSP.cache = {
-	guid = nil,
-	data = nil,
-	time = 0,
-};
+---Cache resolved player results for this generation cycle by GUID
+---The values are the array TryGetMSPData returns.
+---@type table<string, table>
+MSP.cache = {};
+
+---A generation cycle is set by GetTime() and dropped when it goes past CACHE_RESET_TIME.
+---@type number
+local cacheGeneration = 0;
+
+local invalidateCache = false;
+
+---Invalidates the MSP cache; the next TryGetMSPData call drops every cached player.
+function MSP.InvalidateCache()
+	invalidateCache = true;
+end
 
 ---True once TRP3 has fired WORKFLOW_ON_LOADED. TRP3_API existing does not mean it is ready
 local trp3Ready = false;
@@ -228,13 +238,6 @@ function MSP.IsTRPReady()
 	return trp3Ready;
 end
 
-local invalidateCache = false;
-
----Invalidates the MSP cache, forcing the next TryGetMSPData call to fetch fresh data.
-function MSP.InvalidateCache()
-	invalidateCache = true;
-end
-
 ---Called from the TRP3 module once WORKFLOW_ON_LOADED fires. Any result cached before this
 ---point was resolved without TRP3 data, so the cache is dropped as well.
 function MSP.SetTRPReady()
@@ -266,13 +269,16 @@ function MSP.TryGetMSPData(playerName, playerGUID, forceInvalidate)
 
 	local now = GetTime();
 
-	-- Return cached result if same GUID, still valid, and has meaningful data.
-	if not invalidateCache and MSP.cache.guid == playerGUID
-		and MSP.cache.data
-		and (now - MSP.cache.time) <= Constants.MSP.CACHE_RESET_TIME
-		and HasValidMSPData(MSP.cache.data)
-	then
-		local cached = MSP.cache.data;
+	-- Drop the whole generation cycle after it expires, or when an invalidation is pending.
+	if invalidateCache or (now - cacheGeneration) > Constants.MSP.CACHE_RESET_TIME then
+		wipe(MSP.cache);
+		cacheGeneration = now;
+		invalidateCache = false;
+	end
+
+	-- Return the cached result if this player was already resolved this generation cycle.
+	local cached = MSP.cache[playerGUID];
+	if cached and HasValidMSPData(cached) then
 		return
 			NormalizeString(cached[1]),
 			NormalizeString(cached[2]),
@@ -321,11 +327,8 @@ function MSP.TryGetMSPData(playerName, playerGUID, forceInvalidate)
 	-- Normalise to ColorMixin, falling back to class colour.
 	nameColor = ED.Utils.NormalizeColor(nameColor) or ED.Utils.NormalizeColor(GetClassColor(playerGUID));
 
-	-- Store result in cache.
-	MSP.cache.guid = playerGUID;
-	MSP.cache.time = now;
-	MSP.cache.data = { fullName, firstName, nameColor, lastName, className, raceName };
-	invalidateCache = false;
+	-- Store the result in the current generation cycle.
+	MSP.cache[playerGUID] = { fullName, firstName, nameColor, lastName, className, raceName };
 
 	return fullName, firstName, nameColor, lastName, className, raceName;
 end

--- a/Core/MSPHandler.lua
+++ b/Core/MSPHandler.lua
@@ -18,9 +18,31 @@ local cacheGeneration = 0;
 
 local invalidateCache = false;
 
+---Maps Name-Realm to GUID for everything in MSP.cache.
+---MSP and TRP3 identify players by name; the cache itself is keyed by GUID.
+---@type table<string, string>
+local cacheNames = {};
+
+---Drops every cached player and the name index with it.
+local function WipeCache()
+	wipe(MSP.cache);
+	wipe(cacheNames);
+end
+
 ---Invalidates the MSP cache; the next TryGetMSPData call drops every cached player.
 function MSP.InvalidateCache()
 	invalidateCache = true;
+end
+
+---Drops a single player, leaving every other cached player intact.
+---@param playerName string
+function MSP.InvalidatePlayer(playerName)
+	local key = ED.Utils.AddRealmSuffix(playerName);
+	local guid = cacheNames[key];
+	if not guid then return; end
+
+	MSP.cache[guid] = nil;
+	cacheNames[key] = nil;
 end
 
 ---True once TRP3 has fired WORKFLOW_ON_LOADED. TRP3_API existing does not mean it is ready
@@ -269,9 +291,11 @@ function MSP.TryGetMSPData(playerName, playerGUID, forceInvalidate)
 
 	local now = GetTime();
 
-	-- Drop the whole generation cycle after it expires, or when an invalidation is pending.
-	if invalidateCache or (now - cacheGeneration) > Constants.MSP.CACHE_RESET_TIME then
-		wipe(MSP.cache);
+	-- Drop the whole generation cycle when an invalidation is pending, or when the max time
+	-- expires it. Invalidation is event-driven now, so the max time only catches missed events.
+	local cacheMaxTime = Constants.MSP.CACHE_RESET_TIME;
+	if invalidateCache or (cacheMaxTime > 0 and (now - cacheGeneration) > cacheMaxTime) then
+		WipeCache();
 		cacheGeneration = now;
 		invalidateCache = false;
 	end
@@ -328,7 +352,12 @@ function MSP.TryGetMSPData(playerName, playerGUID, forceInvalidate)
 	nameColor = ED.Utils.NormalizeColor(nameColor) or ED.Utils.NormalizeColor(GetClassColor(playerGUID));
 
 	-- Store the result in the current generation cycle.
-	MSP.cache[playerGUID] = { fullName, firstName, nameColor, lastName, className, raceName };
+	-- A nil colour means MSP had nothing and GetPlayerInfoByGUID could not resolve the GUID.
+	-- Nothing will tell us when that changes, so leave it uncached and resolve again next draw.
+	if nameColor then
+		MSP.cache[playerGUID] = { fullName, firstName, nameColor, lastName, className, raceName };
+		cacheNames[ED.Utils.AddRealmSuffix(playerName)] = playerGUID;
+	end
 
 	return fullName, firstName, nameColor, lastName, className, raceName;
 end
@@ -342,8 +371,13 @@ function MSP.Init()
 	if not MSP.IsEnabled() then return; end
 
 	table.insert(msp.callback["updated"], function(senderID, field)
-		if ED.Globals.player_sender_name ~= senderID then return; end
 		if not Constants.MSP_RELEVANT_FIELDS[field] then return; end
+
+		-- Other players: drop their entry only; a refresh here would fire on every event.
+		if ED.Globals.player_sender_name ~= senderID then
+			MSP.InvalidatePlayer(senderID);
+			return;
+		end
 
 		-- Cancel any pending refresh before scheduling a new one.
 		if pendingRefresh then

--- a/Core/MSPHandler.lua
+++ b/Core/MSPHandler.lua
@@ -388,7 +388,7 @@ function MSP.Init()
 		-- Debounce: wait 0.5 s in case multiple fields update in the same frame.
 		pendingRefresh = C_Timer.NewTicker(0.5, function()
 			pendingRefresh = nil;
-			MSP.InvalidateCache();
+			MSP.InvalidatePlayer(senderID);
 			ED.Keywords:ParseList();
 			ED.QuestText:RefreshPlayerPreferredName();
 		end, 1);

--- a/Core/Magnifier.lua
+++ b/Core/Magnifier.lua
@@ -174,7 +174,7 @@ function Magnifier:HandleUpdate(reason)
 
 	-- Keep the chat timestamp ticker alive while a unit is magnified.
 	if unitGUID then
-		createTicker(self, "EavesdropperUpdate", Constants.CHAT_UPDATE_THROTTLE_DEFAULT, tickerCallback);
+		createTicker(self, "EavesdropperUpdate", Constants.WINDOW_REFRESH_INTERVAL, tickerCallback);
 	else
 		stopTicker(self, "EavesdropperUpdate");
 	end

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -255,14 +255,21 @@ function Utils.StripRealmSuffix(name)
 	return name:match("^(.-)%-.+$") or name;
 end
 
+---Appends the home realm to a name with none, normalized to match Chomp.NameMergedRealm.
+---@param name string?
+---@return string
+function Utils.AddRealmSuffix(name)
+	if type(name) ~= "string" or name == "" then return ""; end
+	if name:find("-", 1, true) then return name; end
+	return name .. "-" .. GetRealmName():gsub("[%s%-%.]*", "");
+end
+
 ---IsOwnPlayer Checks if the sender is the current player
 ---@param sender string
 ---@param event string
 ---@return boolean
 function Utils.IsOwnPlayer(sender, event)
-	if not sender:find('-') then
-		sender = sender .. "-" .. GetRealmName():gsub("[%s%-%.]*", "");
-	end
+	sender = Utils.AddRealmSuffix(sender);
 	return sender == Utils.GetUnitName()
 		or event == "CHAT_MSG_WHISPER_INFORM"
 		or (type(sender) == "string" and sender:match("^@.+%-self$"));

--- a/Modules/TRP/TRP.lua
+++ b/Modules/TRP/TRP.lua
@@ -14,6 +14,18 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 	ED.MSP.SetTRPReady();
 end);
 
+-- Drops cached MSP data when TRP3's register changes. Not in onStart, for the same reason.
+TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.REGISTER_DATA_UPDATED, function(_, unitID)
+	-- A nil unitID means some profile changed without telling us which character, so the only
+	-- safe answer is to drop everything. This is probably very rare, but let's still handle it.
+	if not unitID then
+		ED.MSP.InvalidateCache();
+		return;
+	end
+
+	ED.MSP.InvalidatePlayer(unitID);
+end);
+
 ---Registers the Eavesdropper toolbar button once TRP3's workflow is fully loaded.
 local function onStart()
 	TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, function()

--- a/UI/EavesdropperDedicatedFrame.lua
+++ b/UI/EavesdropperDedicatedFrame.lua
@@ -1,9 +1,6 @@
 -- Copyright The Eavesdropper Authors
 -- SPDX-License-Identifier: GPL-3.0-or-later
 
----@type EavesdropperConstants
-local Constants = ED.Constants;
-
 ---@class EavesdropperDedicatedFrame
 local DedicatedFrame = {};
 
@@ -89,11 +86,7 @@ end
 
 function Eavesdropper_Dedicated_FrameMixin:OnShow()
 	self:RefreshChat();
-	if not self.chatTicker then
-		self.chatTicker = C_Timer.NewTicker(Constants.CHAT_UPDATE_THROTTLE_DEFAULT, function()
-			self:RefreshChat(true);
-		end);
-	end
+	self:StartChatTicker();
 end
 
 function Eavesdropper_Dedicated_FrameMixin:OnHide()
@@ -163,6 +156,7 @@ function Eavesdropper_Dedicated_FrameMixin:RefreshChat(retainScroll)
 
 	local scrollOffset = self.ChatBox:GetScrollOffset();
 	self.ChatBox:Clear();
+	self.newestEntryTime = nil;
 
 	local maxMessages = ED.Database:GetSetting("MaxHistory");
 	local player = self.eavesdropped_player;
@@ -202,6 +196,9 @@ function Eavesdropper_Dedicated_FrameMixin:AddMessage(entry, fromHistory)
 	local r, g, b = ED.ChatFormatter.GetEntryColor(entry);
 	local formatted = ED.ChatFormatter:FormatMessage(entry);
 	self.ChatBox:AddMessage(formatted, r, g, b);
+
+	-- Only track lines (to keep frame awake) when they are actually inserted.
+	self:TrackNewestEntry(entry);
 end
 
 ---Override of the base TryAddMessage to handle the new-message indicator

--- a/UI/EavesdropperFrame.lua
+++ b/UI/EavesdropperFrame.lua
@@ -81,6 +81,14 @@ function Eavesdropper_FrameMixin:OnHide()
 	if self.alphaChannelMode and self.SetAlphaChannelMode then
 		self:SetAlphaChannelMode(nil);
 	end
+
+	-- Instance frames get this from OnHideInstanceFrame; the main frame has to do it itself.
+	self:ResetNewIndicator();
+
+	if self.newIndicatorTimer then
+		self.newIndicatorTimer:Cancel();
+		self.newIndicatorTimer = nil;
+	end
 end
 
 -- ============================================================
@@ -311,6 +319,23 @@ function Eavesdropper_FrameMixin:AddMessage(entry, fromHistory)
 
 	-- Only track lines (to keep frame awake) when they are actually inserted.
 	self:TrackNewestEntry(entry);
+end
+
+---Override of the base TryAddMessage to handle the new-message indicator.
+---Only live messages reach TryAddMessage, so a target change never flashes the indicator.
+---@param entry EavesdropperChatEntry
+function Eavesdropper_FrameMixin:TryAddMessage(entry)
+	Eavesdropper_SharedFrameMixin.TryAddMessage(self, entry);
+
+	if not entry.p
+		and ED.ChatFilters:HasEvent(entry.e, self)
+		and ED.Database:GetGlobalSetting("WindowNewIndicator")
+		and self.NewIndicator
+		and not self.isMouseOver
+	then
+		self:FadeInNewIndicator();
+		self:ScheduleNewIndicatorFadeOut();
+	end
 end
 
 ---Apply all profile settings and refresh the settings UI.

--- a/UI/EavesdropperFrame.lua
+++ b/UI/EavesdropperFrame.lua
@@ -219,10 +219,9 @@ function Eavesdropper_FrameMixin:UpdateTarget()
 	-- Nothing to track and nothing previously tracked
 	if not target and not EAVESDROP_TARGET then return; end
 
-	-- Skip if same target and recently updated (throttle 10 sec by default)
-	-- Logically we never hit this, as UpdateTarget is typically already on a 10s timer, so this is a safety net)
+	-- Safety net for UpdateTarget arriving from several sources at once, not a refresh timer.
 	local now = GetTime();
-	if EAVESDROP_TARGET == target and now - (self.lastUpdate or 0) < Constants.CHAT_UPDATE_THROTTLE_DEFAULT then
+	if EAVESDROP_TARGET == target and now - (self.lastUpdate or 0) < Constants.TARGET_UPDATE_THROTTLE then
 		return;
 	end
 
@@ -263,6 +262,7 @@ function Eavesdropper_FrameMixin:RefreshChat()
 
 	self.refreshing = true;
 	self.ChatBox:Clear();
+	self.newestEntryTime = nil;
 
 	local maxMessages = ED.Database:GetSetting("MaxHistory");
 	local player = self.eavesdropped_player;
@@ -298,6 +298,9 @@ function Eavesdropper_FrameMixin:AddMessage(entry, fromHistory)
 	local r, g, b = ED.ChatFormatter.GetEntryColor(entry);
 	local formatted = ED.ChatFormatter:FormatMessage(entry);
 	self.ChatBox:AddMessage(formatted, r, g, b);
+
+	-- Only track lines (to keep frame awake) when they are actually inserted.
+	self:TrackNewestEntry(entry);
 end
 
 ---Apply all profile settings and refresh the settings UI.

--- a/UI/EavesdropperFrame.lua
+++ b/UI/EavesdropperFrame.lua
@@ -243,11 +243,14 @@ function Eavesdropper_FrameMixin:UpdateTarget()
 		self.eavesdropped_player_guid = nil;
 	end
 
-	-- Refresh when target changed or chat is scrolled to the bottom
-	if hardUpdate or (self.ChatBox and self.ChatBox:AtBottom()) then
+	-- A new target starts at the bottom; otherwise hold the scroll and skip windows that cannot change.
+	if hardUpdate then
 		self:RefreshChat();
-		self.lastUpdate = now;
+	elseif not self:IsTimestampFrozen() then
+		self:RefreshChat(true);
 	end
+
+	self.lastUpdate = now;
 
 	self:HandleVisibility();
 end
@@ -257,10 +260,13 @@ end
 -- ============================================================
 
 ---Repopulate the chat box from stored history
-function Eavesdropper_FrameMixin:RefreshChat()
+---@param retainScroll boolean? If true, retain the previous scroll position.
+function Eavesdropper_FrameMixin:RefreshChat(retainScroll)
 	if not self.ChatBox then return; end
 
 	self.refreshing = true;
+
+	local scrollOffset = self.ChatBox:GetScrollOffset();
 	self.ChatBox:Clear();
 	self.newestEntryTime = nil;
 
@@ -269,6 +275,10 @@ function Eavesdropper_FrameMixin:RefreshChat()
 
 	if player then
 		self:PopulateHistoryMessages(player, maxMessages);
+	end
+
+	if retainScroll then
+		self.ChatBox:SetScrollOffset(scrollOffset or 0);
 	end
 
 	self:UpdateTitleBar();

--- a/UI/EavesdropperFrame.xml
+++ b/UI/EavesdropperFrame.xml
@@ -38,6 +38,43 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Layers>
 
 		<Frames>
+			<Frame parentKey="NewIndicator" hidden="true">
+				<Anchors>
+					<Anchor point="TOPLEFT" x="0" y="0"/>
+					<Anchor point="BOTTOMRIGHT" x="0" y="0"/>
+				</Anchors>
+				<Layers>
+					<Layer level="ARTWORK">
+						<Texture>
+							<Size y="32"/>
+							<Color r="0.95" g="0.75" b="0.1" a="1"/>
+							<Anchors>
+								<Anchor point="BOTTOMLEFT" relativeKey="$parent" relativePoint="BOTTOMLEFT"/>
+								<Anchor point="BOTTOMRIGHT" relativeKey="$parent" relativePoint="BOTTOMRIGHT"/>
+							</Anchors>
+							<Gradient orientation="VERTICAL">
+								<MinColor a="0.5" r="0.95" g="0.75" b="0.1"/>
+								<MaxColor a="0.0" r="0.95" g="0.75" b="0.1"/>
+							</Gradient>
+						</Texture>
+					</Layer>
+				</Layers>
+
+				<Animations>
+					<AnimationGroup parentKey="NewIndicatorFadeIn" setToFinalAlpha="true">
+						<Alpha fromAlpha="0" toAlpha="1" duration="0.3" order="1"/>
+					</AnimationGroup>
+					<AnimationGroup parentKey="NewIndicatorFadeOut" setToFinalAlpha="true">
+						<Alpha fromAlpha="1" toAlpha="0" duration="0.3" order="1"/>
+						<Scripts>
+							<OnFinished>
+								self:GetParent():Hide();
+							</OnFinished>
+						</Scripts>
+					</AnimationGroup>
+				</Animations>
+			</Frame>
+
 			<!-- Title Bar -->
 			<Frame parentKey="TitleBar" registerForDrag="LeftButton" hidden="true">
 				<Anchors>

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -189,7 +189,7 @@ end
 -- ============================================================
 
 ---Fade out the new-indicator (if active) then delegate hover state to ShowTitleBar.
----FadeOutNewIndicator is a no-op on frames without a NewIndicator widget (e.g. main frame).
+---FadeOutNewIndicator is a no-op on frames without a NewIndicator widget.
 function Eavesdropper_SharedFrameMixin:OnEnter()
 	if self.isMouseOver then return; end
 	self.isMouseOver = true;

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -59,10 +59,7 @@ end
 function Eavesdropper_SharedFrameMixin:OnHideInstanceFrame()
 	if not UIParent:IsShown() or self.isCombatHidden then return; end
 
-	if self.chatTicker then
-		self.chatTicker:Cancel();
-		self.chatTicker = nil;
-	end
+	self:StopChatTicker();
 
 	self:ResetNewIndicator();
 
@@ -90,6 +87,55 @@ end
 
 ---Override in concrete mixins to remove self from the owning frame-manager table.
 function Eavesdropper_SharedFrameMixin:OnUnregisterFrame()
+end
+
+-- ============================================================
+-- Chat refresh ticker
+-- ============================================================
+
+---Returns true when no line in this window can still change with age.
+---An empty window counts as frozen.
+---@return boolean
+function Eavesdropper_SharedFrameMixin:IsTimestampFrozen()
+	if not self.newestEntryTime then return true; end
+	return (time() - self.newestEntryTime) >= Constants.TIMESTAMP_FREEZE_AGE;
+end
+
+---Start the periodic refresh that ages the timestamps on this window.
+---The first tick is offset randomly, so windows shown together do not refresh in the same frame.
+---Stops itself once every line is frozen; TryAddMessage starts it again.
+function Eavesdropper_SharedFrameMixin:StartChatTicker()
+	self.usesChatTicker = true;
+
+	if self.chatTicker or self.chatTickerDelay then return; end
+
+	local interval = Constants.WINDOW_REFRESH_INTERVAL;
+
+	self.chatTickerDelay = C_Timer.NewTimer(math.random() * interval, function()
+		self.chatTickerDelay = nil;
+		self.chatTicker = C_Timer.NewTicker(interval, function()
+			-- Refresh before testing; the tick that freezes a window still has a label to draw.
+			self:RefreshChat(true);
+
+			if self:IsTimestampFrozen() then
+				self:StopChatTicker();
+			end
+		end);
+	end);
+end
+
+---Cancel the periodic refresh and any pending staggered start.
+---The stagger uses NewTimer rather than After so it can be cancelled here.
+function Eavesdropper_SharedFrameMixin:StopChatTicker()
+	if self.chatTickerDelay then
+		self.chatTickerDelay:Cancel();
+		self.chatTickerDelay = nil;
+	end
+
+	if self.chatTicker then
+		self.chatTicker:Cancel();
+		self.chatTicker = nil;
+	end
 end
 
 -- ============================================================
@@ -480,6 +526,17 @@ function Eavesdropper_SharedFrameMixin:PopulateHistoryMessages(player, maxMessag
 	end
 end
 
+---Record the newest displayed entry's timestamp, read by IsTimestampFrozen.
+---Takes the maximum, as group windows merge several histories out of order.
+---@param entry EavesdropperChatEntry
+function Eavesdropper_SharedFrameMixin:TrackNewestEntry(entry)
+	if not entry.t then return; end
+
+	if not self.newestEntryTime or entry.t > self.newestEntryTime then
+		self.newestEntryTime = entry.t;
+	end
+end
+
 ---Record the clickblock timestamp then delegate to AddMessage.
 ---Dedicated and Group frames override this to also handle the new-message indicator.
 ---@param entry EavesdropperChatEntry
@@ -489,6 +546,11 @@ function Eavesdropper_SharedFrameMixin:TryAddMessage(entry)
 	end
 
 	self:AddMessage(entry);
+
+	-- A new message un-freezes the window; the flag skips the Magnifier-driven main frame.
+	if self.usesChatTicker then
+		self:StartChatTicker();
+	end
 end
 
 -- ============================================================

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -139,6 +139,64 @@ function Eavesdropper_SharedFrameMixin:StopChatTicker()
 end
 
 -- ============================================================
+-- Data-driven refresh (MSP invalidation)
+-- ============================================================
+
+---True while the burst window's cooldown is running.
+local dataRefreshOnCooldown = false;
+
+---True if an invalidation arrived during the cooldown and still needs a redraw.
+local dataRefreshPending = false;
+
+---Redraw every open dedicated and group window, and the main window if it's shown.
+local function RefreshAllWindows()
+	ED.DedicatedFrame:ForEachFrame(function(frame)
+		frame:RefreshChat(true);
+	end);
+
+	ED.GroupFrame:ForEachFrame(function(frame)
+		frame:RefreshChat(true);
+	end);
+
+	if ED.Frame:IsShown() then
+		ED.Frame:RefreshChat(true);
+	end
+end
+
+---Rearms itself if something is pending when the cooldown expires, rather than always going
+---idle. Keeps a sustained burst on a steady interval instead of having it basically spam.
+local function ArmDataRefreshCooldown()
+	C_Timer.NewTimer(Constants.DATA_REFRESH_THROTTLE, function()
+		if not dataRefreshPending then
+			dataRefreshOnCooldown = false;
+			ED.Debug:Print("ScheduleDataRefresh: cooldown expired, idle");
+			return;
+		end
+
+		dataRefreshPending = false;
+		ED.Debug:Print("ScheduleDataRefresh: cooldown expired, trailing redraw");
+		RefreshAllWindows();
+		ArmDataRefreshCooldown();
+	end);
+end
+
+---Entry point for MSP invalidation to request a redraw. Invalidation sources must always
+---come through here, never call RefreshChat directly.
+function Eavesdropper_SharedFrameMixin.ScheduleDataRefresh()
+	if dataRefreshOnCooldown then
+		dataRefreshPending = true;
+		ED.Debug:Print("ScheduleDataRefresh: on cooldown, queued");
+		return;
+	end
+
+	ED.Debug:Print("ScheduleDataRefresh: leading edge, redrawing now");
+	RefreshAllWindows();
+
+	dataRefreshOnCooldown = true;
+	ArmDataRefreshCooldown();
+end
+
+-- ============================================================
 -- Scroll Marker
 -- ============================================================
 

--- a/UI/EavesdropperGroupFrame.lua
+++ b/UI/EavesdropperGroupFrame.lua
@@ -260,7 +260,7 @@ function Eavesdropper_Group_FrameMixin:TryAddMessage(entry)
 	Eavesdropper_SharedFrameMixin.TryAddMessage(self, entry);
 
 	if not entry.p
-		-- TODO: and ED.Database:GetGlobalSetting("GroupWindowsNewIndicator")
+		and ED.Database:GetGlobalSetting("GroupWindowsNewIndicator")
 		and ED.ChatFilters:HasEvent(entry.e, self)
 		and self.NewIndicator
 		and not self.isMouseOver

--- a/UI/EavesdropperGroupFrame.lua
+++ b/UI/EavesdropperGroupFrame.lua
@@ -1,9 +1,6 @@
 -- Copyright The Eavesdropper Authors
 -- SPDX-License-Identifier: GPL-3.0-or-later
 
----@type EavesdropperConstants
-local Constants = ED.Constants;
-
 local L = ED.Localization;
 
 ---@class EavesdropperGroupFrame
@@ -107,11 +104,7 @@ end
 
 function Eavesdropper_Group_FrameMixin:OnShow()
 	self:RefreshChat();
-	if not self.chatTicker then
-		self.chatTicker = C_Timer.NewTicker(Constants.CHAT_UPDATE_THROTTLE_DEFAULT, function()
-			self:RefreshChat(true);
-		end);
-	end
+	self:StartChatTicker();
 end
 
 function Eavesdropper_Group_FrameMixin:OnHide()
@@ -178,6 +171,7 @@ function Eavesdropper_Group_FrameMixin:RefreshChat(retainScroll)
 
 	local scrollOffset = self.ChatBox:GetScrollOffset();
 	self.ChatBox:Clear();
+	self.newestEntryTime = nil;
 
 	local maxMessages = ED.Database:GetSetting("MaxHistory");
 
@@ -252,6 +246,9 @@ function Eavesdropper_Group_FrameMixin:AddMessage(entry, fromHistory)
 	local r, g, b = ED.ChatFormatter.GetEntryColor(entry);
 	local formatted = ED.ChatFormatter:FormatMessage(entry, true, self.nameDisplayMode);
 	self.ChatBox:AddMessage(formatted, r, g, b);
+
+	-- Only track lines (to keep frame awake) when they are actually inserted.
+	self:TrackNewestEntry(entry);
 end
 
 ---Override of the base TryAddMessage to handle the new-message indicator.

--- a/UI/SettingsFrame.lua
+++ b/UI/SettingsFrame.lua
@@ -568,6 +568,17 @@ function Eavesdropper_SettingsMixin:OnLoad()
 		{
 			type = "checkbox",
 			global = true,
+			label = L.NEW_WINDOWS_NEW_INDICATOR,
+			tooltip = L.NEW_WINDOWS_NEW_INDICATOR_HELP,
+			buildAdded = "0.6.0|120100",
+			get = function() return ED.Database:GetGlobalSetting("WindowNewIndicator"); end,
+			set = function(val)
+				ED.Database:SetGlobalSetting("WindowNewIndicator", val);
+			end,
+		},
+		{
+			type = "checkbox",
+			global = true,
 			label = L.WELCOME_MSG,
 			tooltip = L.WELCOME_MSG_HELP,
 			get = function() return ED.Database:GetGlobalSetting("WelcomeMessage"); end,


### PR DESCRIPTION
## 1. Optimize MSP.cache

Every MSP cache cycle (where MSP data is generated) now caches multiple players instead of one at a time. This is mostly noticeable in groups with many players. As every time a different name had to be rendered, it would overwrite the old one, grab the new one and then do it again for the next name.

Measured on a group window showing 300 lines from 20 different players, a refresh went from ~14.5ms to ~7.5ms, so roughly half.

The gain scales with how many different people are talking. A Dedicated window only tracks one player, so it sees no change, as the old cache already handled that case fine.

InvalidateCache() now drops every cached player rather than only forcing the next lookup to refetch. This matters for SetTRPReady, which calls it because everything cached before TRP3 finished loading was resolved without TRP3 data. Previously only the next single lookup got corrected.

## 2. Change window refresh to once a minute & stop once timestamps freeze

Our timestamps render every whole minute up until 30 minutes. So our re-drawing every 10s to update timestamps was a bit overkill. That 10s timer was also doing duty as UpdateTarget's throttle, which meant a refresh could occasionally get swallowed by it. It's now its own 1s constant, separate from the refresh interval to avoid issues.

We now have a fixed 60s timer for timestamp refreshes when under 30 minutes. Above 30 minutes, Dedicated & Group Windows go into a 'freeze' given timestamps no longer require any updates anymore. The freeze is stopped when a new message is added to the frame.

Given a refresh is a full rebuild (frame cleared, every line reformatted, etc), it scales with the amount of messages and windows opened. Group Window were probably the worst offender as they merge lines of several people. Each of those windows also offsets its first tick randomly, so windows opened together spread their rebuilds out instead of all landing on the same frame (which could be noticed to be problematic after like a /reload or something, when all windows would refresh together). Frozen windows cancel their timers, so there is no work to be queued up and makes it a 'free' window to hold basically.

One downside changing the refresh from 10s to 60s is that RP names 'update' on this same refresh, so a name change can now take up to a minute to show (and not at all if a window is frozen until a new message comes in). Changes to how MSP data is pulled in are targeted for a later commit to mitigate this issue somewhat.

## 3. Update main window even when scrolled up

`retainScroll` is now used for the main Eavesdropper frame's RefreshChat (as Dedicated & Group Windows did). Prior we stopped the main window from updating when scrolled up as we didn't properly handle keeping the scroll position (and throwing someone down at the bottom of the chat for nothing is stupid). Upside is that timestamps and RP names will now update in the main frame even when you're scrolled up (yay).

When there is nothing coming in, and we're at the bottom, we don't trigger refreshes until a new message comes in or we change target/mouseover/etc. This basically makes that window "free" as it has to do no calculations.

## 4. Add a New Message Indicator to the main window

Ported this feature from Dedicated Window and fixed up the mixins (fade in, fade out, hover to dismiss, etc) to work for all the frames. Saved as a global (as the other ones are), and added under Appearance > Display.

The trigger overrides TryAddMessage rather than AddMessage. Only live messages reach TryAddMessage, while changing target/mouse adds the history through AddMessage. Which prevents that from flashing the indicator for messages that were already seen / switched.

Main Window uses OnHide over the other two's OnHideInstanceFrame, as the OnHide resets indicator and cancels pending fade-out timers. So if the window is hid mid-flash, it won't flash again when it shows again.

## 5. Move MSP cache invalidation to events instead of a timer

MSP.cache dropped everything every 5 seconds, but our frames only refresh every 60 seconds. This meant that on every refresh the MPS cache was considered 'stale' and would have to be re-resolved.

It is not event-driven by listening to LibMSP's "updated" callback (which fires when changes come in). We invalidate the person's cache that sends updated instead of invalidate all. We do have to resolve name to GUID (MSP works by name) to make it work for Eavesdropper but that is pretty easy.

For now, we do have a 'max cache' time of 5 minutes (will be disabled with 0 after actually testing the impact of these changes). In case the cache does get busted somehow with this new method, things will only be 'broken' for at max 5 minutes.

Important to note is that this does not invalidate a name and makes the chat refresh itself. It just no longer invalidates EVERYTHING at once and just does it for the necessary players.. And then the 1 minute refresh will pick those changes up.

## 6. Add throttled MSP/TRP3-driven refresh for open windows

`MSP.InvalidatePlayer` and `MSP.InvalidateCache` now schedule redraws for every opened window with a 5 second burst window: When data is invalidated it will redraw immediately, with further invalidations within the 5s burst window being collected together for the next redraw. This basically limits situations with many invalidations to redraw at worst case every 5 seconds.

This was required to make Eavesdropper more event-driven in general with its MSP cache. We already invalidated stale data but did not make the new data refresh anything until the 60s timer to refresh the timestamp was called. MSP name changes will now manifest in Eavesdropper windows within max 5s. This is a speed-up from prior to all these performance commits, which only did a refresh of data every 10s. It is now fully independent of the timestamp refresh timer, which means if in the future we decide to raise that fixed timer it does not affect stale MSP data.