### PR TITLE
Group Window history size slider & introduce chunking for large groups

### DIFF
--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -38,11 +38,17 @@ Constants.CHANNELS_TO_SKIP_NOTIFICATIONS = {
 ---@field MAX_FONT_SIZE number
 ---@field MIN_HISTORY number
 ---@field MAX_HISTORY number
+---@field MIN_GROUP_HISTORY number
+---@field MAX_GROUP_HISTORY number
+---@field GROUP_CHUNK_THRESHOLD number Gathered entries (tracked players x GroupHistorySize) above which a Group Window's rebuild spreads across frames instead of running synchronously.
 Constants.CHAT_BOX = {
 	MIN_FONT_SIZE = 6,
 	MAX_FONT_SIZE = 24,
 	MIN_HISTORY   = 10,
 	MAX_HISTORY   = 300,
+	MIN_GROUP_HISTORY = 10,
+	MAX_GROUP_HISTORY = 1000,
+	GROUP_CHUNK_THRESHOLD = 2000,
 };
 
 ---All chat events the addon registers filters for.

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -30,6 +30,7 @@ local Database = {};
 ---@field DedicatedWindowsUnitPopups boolean?
 ---@field DedicatedWindowsPersist boolean?
 ---@field Flyway EavesdropperFlyway? Database patch versioning and migration tracking.
+---@field GroupHistorySize number?
 ---@field GroupWindows boolean?
 ---@field GroupWindowsNewIndicator boolean?
 ---@field GroupWindowsUnitPopups boolean?
@@ -51,6 +52,7 @@ local GLOBAL_DEFAULTS = {
 		CurrentBuild = 0,
 		Log = "",
 	},
+	GroupHistorySize = 100,
 	GroupWindows = true,
 	GroupWindowsNewIndicator = true,
 	GroupWindowsNPCSpeechDetectionNameShown = false,
@@ -725,6 +727,7 @@ end
 ---| "DedicatedWindowsUnitPopups"
 ---| "DedicatedWindowsPersist"
 ---| "Flyway"
+---| "GroupHistorySize"
 ---| "GroupWindows"
 ---| "GroupWindowsNewIndicator"
 ---| "GroupWindowsNPCSpeechDetectionNameShown"

--- a/Core/ProfileTransfer.lua
+++ b/Core/ProfileTransfer.lua
@@ -55,6 +55,12 @@ local NUMERIC_BOUNDS = {
 	NotificationThrottle = { min = 0 },
 };
 
+---Global keys clamped to a numeric range. Same shape as NUMERIC_BOUNDS, kept separate since
+---global and profile settings are sanitized through different functions.
+local GLOBAL_NUMERIC_BOUNDS = {
+	GroupHistorySize = { min = Constants.CHAT_BOX.MIN_GROUP_HISTORY, max = Constants.CHAT_BOX.MAX_GROUP_HISTORY },
+};
+
 ---Profile keys holding an r/g/b(/a) colour.
 local COLOR_KEYS = {
 	ColorBackground = true,
@@ -247,6 +253,9 @@ function ProfileTransfer.SanitizeGlobals(data)
 			dropped = dropped + 1;
 		elseif type(value) == "table" then
 			clean[key] = sanitizeShape(value, default, EXTRA_SHAPE_FIELDS[key]);
+		elseif GLOBAL_NUMERIC_BOUNDS[key] then
+			local bounds = GLOBAL_NUMERIC_BOUNDS[key];
+			clean[key] = bounds.max and Clamp(value, bounds.min, bounds.max) or math.max(value, bounds.min);
 		else
 			clean[key] = value;
 		end

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -194,6 +194,9 @@ L = {
 	GROUP_WINDOWS_PERSIST = "Save Groups",
 	GROUP_WINDOWS_PERSIST_HELP = "Toggles whether Group Window configurations are saved across game restarts or UI reloads.|n|nThe following data is preserved:|n- Group Window name|n- List of included players|n- Name Display Mode settings|n|n|cnWARNING_FONT_COLOR:Note: Visual settings such as font size and window positions are not saved and will reset.|r",
 
+	GROUP_HISTORY_SIZE = "History Size",
+	GROUP_HISTORY_SIZE_HELP = "Set the maximum number of history messages Eavesdropper displays for each Group Window, merged across every tracked player.|n|n|cnWARNING_FONT_COLOR:Note: High values on a Group Window tracking many players may cause temporary frame drops when refreshing the history window.|r",
+
 	GROUP_OPTIONS = "Group Options",
 	GROUP_RENAME = "Change Group Name",
 

--- a/Modules/Flyway/Flyway.lua
+++ b/Modules/Flyway/Flyway.lua
@@ -5,7 +5,7 @@
 ---@class EavesdropperFlyway
 local Flyway = {};
 
-local SCHEMA_VERSION = 1;
+local SCHEMA_VERSION = 2;
 
 local function ApplyPatches(fromBuild, toBuild)
 	local patched = false;

--- a/Modules/Flyway/FlywayPatches.lua
+++ b/Modules/Flyway/FlywayPatches.lua
@@ -2,6 +2,9 @@
 -- Inspired by Total RP 3, Sippy Cup
 -- SPDX-License-Identifier: GPL-3.0-or-later
 
+---@type EavesdropperConstants
+local Constants = ED.Constants;
+
 ED.Flyway.Patches = {};
 
 ED.Flyway.Patches["1"] = {
@@ -26,4 +29,25 @@ ED.Flyway.Patches["1"] = {
 	end,
 
 	description = "Migrate profile-specific ElvUITheme to global, if disabled (default was enabled), we disable it globally.",
+};
+
+ED.Flyway.Patches["2"] = {
+	run = function()
+		if not EavesdropperDB or not EavesdropperDB.profiles then return; end
+
+		local highestMaxHistory = 0;
+
+		for _, profileData in pairs(EavesdropperDB.profiles) do
+			local maxHistory = profileData["MaxHistory"];
+			if type(maxHistory) == "number" and maxHistory > highestMaxHistory then
+				highestMaxHistory = maxHistory;
+			end
+		end
+
+		if highestMaxHistory > ED.Database.globalDefaults.GroupHistorySize then
+			EavesdropperDB.global.GroupHistorySize = Clamp(highestMaxHistory, Constants.CHAT_BOX.MIN_GROUP_HISTORY, Constants.CHAT_BOX.MAX_GROUP_HISTORY);
+		end
+	end,
+
+	description = "Raise the new global GroupHistorySize to match the highest per-profile MaxHistory, so existing large history setups aren't shrunk for Group Windows.",
 };

--- a/UI/EavesdropperDedicatedFrame.lua
+++ b/UI/EavesdropperDedicatedFrame.lua
@@ -1,6 +1,9 @@
 -- Copyright The Eavesdropper Authors
 -- SPDX-License-Identifier: GPL-3.0-or-later
 
+---@type EavesdropperConstants
+local Constants = ED.Constants;
+
 ---@class EavesdropperDedicatedFrame
 local DedicatedFrame = {};
 
@@ -50,7 +53,7 @@ function Eavesdropper_Dedicated_FrameMixin:OnLoad()
 	self:EnableMouseWheel(true);
 	self:UpdateMouseLock();
 
-	Eavesdropper_SharedFrameMixin.InitChatBox(self);
+	Eavesdropper_SharedFrameMixin.InitChatBox(self, Constants.CHAT_BOX.MAX_HISTORY);
 
 	-- Inherit font size from the main frame settings
 	self.FontSize = ED.Database:GetSetting("FontSize");

--- a/UI/EavesdropperFrame.lua
+++ b/UI/EavesdropperFrame.lua
@@ -49,7 +49,7 @@ function Eavesdropper_FrameMixin:OnLoad()
 	self.isMouseOver = false;
 	self.titlebar_name = nil;
 
-	Eavesdropper_SharedFrameMixin.InitChatBox(self);
+	Eavesdropper_SharedFrameMixin.InitChatBox(self, Constants.CHAT_BOX.MAX_HISTORY);
 
 	if ED.Database and not ED.Database:GetSetting("LockWindow") then
 		self.ResizeHandle:Show();

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -22,12 +22,13 @@ Eavesdropper_SharedFrameMixin = {};
 
 ---Configure ChatBox properties
 ---@param frame table
-function Eavesdropper_SharedFrameMixin.InitChatBox(frame)
+---@param maxLines number Lines beyond this are silently dropped, oldest first.
+function Eavesdropper_SharedFrameMixin.InitChatBox(frame, maxLines)
 	frame.ChatBox:SetJustifyH("LEFT");
 	frame.ChatBox:SetIndentedWordWrap(true);
 	frame.ChatBox:SetHyperlinksEnabled(true);
 	frame.ChatBox:SetFading(false);
-	frame.ChatBox:SetMaxLines(300);
+	frame.ChatBox:SetMaxLines(maxLines);
 	frame.ChatBox.ScrollMarker.Text:SetText(L.SCROLLMARKER_TEXT);
 end
 

--- a/UI/EavesdropperGroupFrame.lua
+++ b/UI/EavesdropperGroupFrame.lua
@@ -1,6 +1,9 @@
 -- Copyright The Eavesdropper Authors
 -- SPDX-License-Identifier: GPL-3.0-or-later
 
+---@type EavesdropperConstants
+local Constants = ED.Constants;
+
 local L = ED.Localization;
 
 ---@class EavesdropperGroupFrame
@@ -68,7 +71,7 @@ function Eavesdropper_Group_FrameMixin:OnLoad()
 	self:EnableMouseWheel(true);
 	self:UpdateMouseLock();
 
-	Eavesdropper_SharedFrameMixin.InitChatBox(self);
+	Eavesdropper_SharedFrameMixin.InitChatBox(self, ED.Database:GetGlobalSetting("GroupHistorySize"));
 	self.EmptyLabel.Text:SetText(L.EMPTYLABEL_TEXT);
 
 	-- Inherit font size from the main frame settings
@@ -162,39 +165,52 @@ end
 -- Chat
 -- ============================================================
 
----Repopulate the chat box by merging history from all tracked players
+---Refreshes the chat box. `retainScroll` (used by the timestamp ticker and the MSP-driven
+---refresh) redraws the already-built merged cache; anything else triggers a full rebuild.
 ---@param retainScroll boolean? If true, retain the previous scroll position.
 function Eavesdropper_Group_FrameMixin:RefreshChat(retainScroll)
 	if not self.ChatBox then return; end
 
-	self.refreshing = true;
-
-	local scrollOffset = self.ChatBox:GetScrollOffset();
-	self.ChatBox:Clear();
-	self.newestEntryTime = nil;
-
-	local maxMessages = ED.Database:GetSetting("MaxHistory");
-
-	if self.players and #self.players > 0 then
-		self:PopulateGroupHistoryMessages(maxMessages);
+	if retainScroll and self.mergedHistory then
+		self:RedrawChat(retainScroll);
+		return;
 	end
 
-	if retainScroll then
-		self.ChatBox:SetScrollOffset(scrollOffset or 0);
+	if not self.players or #self.players == 0 then
+		self.mergedHistory = {};
+		self:RedrawChat(retainScroll);
+		return;
 	end
 
-	self.refreshing = false;
+	local maxMessages = ED.Database:GetGlobalSetting("GroupHistorySize");
+	self:RebuildMergedHistory(maxMessages, retainScroll);
 end
 
----Collect and deduplicate history across all tracked players, sort chronologically,
----trim to maxMessages, then feed entries into the ChatBox oldest-first.
+---Collects & deduplicates history across all tracker players, sorts and trims it to chosen
+---maxMessages, and then stores it in self.mergedHistory. As soon as we enter chunking
+---territory (above Constants.CHAT_BOX.GROUP_CHUNK_THRESHOLD) which is tracked
+---players x maxMessages, we make gathering spread out one player per RunNextFrame.
+---Not running sync prevents e.g. adding players to huge groups from causing fps issues.
 ---@param maxMessages number
-function Eavesdropper_Group_FrameMixin:PopulateGroupHistoryMessages(maxMessages)
-	-- Collect entries keyed by entry.id to deduplicate across players
+---@param retainScroll boolean?
+---@param forceSync boolean? Bypasses the chunk threshold to gather synchronously; used by the
+---debug measurement harness.
+function Eavesdropper_Group_FrameMixin:RebuildMergedHistory(maxMessages, retainScroll, forceSync)
+	self.mergeGeneration = (self.mergeGeneration or 0) + 1;
+	local generation = self.mergeGeneration;
+
+	-- Chunking gathering takes time and might span multiple frames, so we keep the current id and table here.
+	-- We can then use this in finish() to still fold new live messages into self.mergedHistory (through AppendToMergedHistory).
+	local rebuildStartId = ED.ChatHistory.nextEntryId;
+	local previousMerged = self.mergedHistory;
+
+	local players = self.players;
 	local seen = {};
 	local entries = {};
 
-	for _, player in ipairs(self.players) do
+	---Gathers one player's history into entries/seen, deduplicating by entry id, as we did in the past.
+	---@param player string
+	local function gatherPlayer(player)
 		local history = ED.ChatHistory:GetPlayerHistory(player, maxMessages, self);
 
 		if not history or #history == 0 then
@@ -205,27 +221,121 @@ function Eavesdropper_Group_FrameMixin:PopulateGroupHistoryMessages(maxMessages)
 			for _, entry in ipairs(history) do
 				if not seen[entry.id] then
 					seen[entry.id] = true;
-					table.insert(entries, entry);
+					entries[#entries + 1] = entry;
 				end
 			end
 		end
 	end
 
-	if #entries == 0 then return; end
+	---Sorts entries ascending by id and trims to maxMessages.
+	local function sortAndTrim()
+		if #entries == 0 then return; end
 
-	-- Sort ascending by ID: lowest ID (oldest) first, highest ID (newest) last
-	table.sort(entries, function(a, b) return a.id < b.id; end);
+		table.sort(entries, function(a, b) return a.id < b.id; end);
 
-	-- Trim to maxMessages total after merging
-	local start = math.max(1, #entries - maxMessages + 1);
-	for i = start, #entries do
-		self:AddMessage(entries[i], true);
+		local start = math.max(1, #entries - maxMessages + 1);
+		local trimmed = {};
+		for i = start, #entries do
+			trimmed[#trimmed + 1] = entries[i];
+		end
+		entries = trimmed;
+	end
+
+	---Sorts and trims the gather, folds in anything appended live since the rebuild started,
+	---stores the result, and redraws. See comment @ rebuildStartId for further info.
+	local function finish()
+		sortAndTrim();
+
+		if previousMerged then
+			local foldedInLive = false;
+
+			for _, entry in ipairs(previousMerged) do
+				if entry.id >= rebuildStartId and not seen[entry.id] then
+					seen[entry.id] = true;
+					entries[#entries + 1] = entry;
+					foldedInLive = true;
+				end
+			end
+
+			if foldedInLive then
+				sortAndTrim();
+			end
+		end
+
+		self.mergedHistory = entries;
+		self:RedrawChat(retainScroll);
+	end
+
+	if forceSync or (#players * maxMessages <= Constants.CHAT_BOX.GROUP_CHUNK_THRESHOLD) then
+		for _, player in ipairs(players) do
+			gatherPlayer(player);
+		end
+		finish();
+		return;
+	end
+
+	-- We use a counter for generation so that an invalidated rebuild is stopped early in favor of the newer one.
+	local index = 0;
+	local function step()
+		if generation ~= self.mergeGeneration then return; end
+
+		index = index + 1;
+		local player = players[index];
+
+		if not player then
+			finish();
+			return;
+		end
+
+		gatherPlayer(player);
+		RunNextFrame(step);
+	end
+
+	step();
+end
+
+---Clears the ChatBox and replays the cached merged history into it. Does not re-gather,
+---dedupe, or sort; callers needing that go through RebuildMergedHistory.
+---@param retainScroll boolean? If true, retain the previous scroll position.
+function Eavesdropper_Group_FrameMixin:RedrawChat(retainScroll)
+	if not self.ChatBox then return; end
+
+	self.refreshing = true;
+
+	local scrollOffset = self.ChatBox:GetScrollOffset();
+	self.ChatBox:Clear();
+	self.newestEntryTime = nil;
+
+	if self.mergedHistory then
+		for _, entry in ipairs(self.mergedHistory) do
+			self:AddMessage(entry, true);
+		end
+	end
+
+	if retainScroll then
+		self.ChatBox:SetScrollOffset(scrollOffset or 0);
+	end
+
+	self.refreshing = false;
+end
+
+---Appends a live entry to the cached merged history, if over cap we trim from the front.
+---Safe as it does not require re-sorting and they have higher IDs so live after the cache.
+---@param entry EavesdropperChatEntry
+function Eavesdropper_Group_FrameMixin:AppendToMergedHistory(entry)
+	if not self.mergedHistory then return; end
+
+	self.mergedHistory[#self.mergedHistory + 1] = entry;
+
+	local maxMessages = ED.Database:GetGlobalSetting("GroupHistorySize");
+	while #self.mergedHistory > maxMessages do
+		table.remove(self.mergedHistory, 1);
 	end
 end
 
 ---Add a chat entry to the frame
 ---@param entry EavesdropperChatEntry
----@param fromHistory boolean
+---@param fromHistory boolean? True when replayed from the merged history cache; false/nil for a live message.
 function Eavesdropper_Group_FrameMixin:AddMessage(entry, fromHistory)
 	if not entry then return; end
 
@@ -239,8 +349,12 @@ function Eavesdropper_Group_FrameMixin:AddMessage(entry, fromHistory)
 
 	if not self.ChatBox then return; end
 
-	if not fromHistory and (ED.Database:GetSetting("HideWhenEmpty") or ED.Frame.settingsOpened) then
-		self:Show();
+	if not fromHistory then
+		if ED.Database:GetSetting("HideWhenEmpty") or ED.Frame.settingsOpened then
+			self:Show();
+		end
+
+		self:AppendToMergedHistory(entry);
 	end
 
 	local r, g, b = ED.ChatFormatter.GetEntryColor(entry);

--- a/UI/SettingsFrame.lua
+++ b/UI/SettingsFrame.lua
@@ -1041,6 +1041,24 @@ function Eavesdropper_SettingsMixin:OnLoad()
 			end,
 		},
 		{
+			type = "slider",
+			global = true,
+			label = L.GROUP_HISTORY_SIZE,
+			tooltip = L.GROUP_HISTORY_SIZE_HELP,
+			buildAdded = "0.6.0|120100",
+			min = Constants.CHAT_BOX.MIN_GROUP_HISTORY,
+			max = Constants.CHAT_BOX.MAX_GROUP_HISTORY,
+			step = 1,
+			get = function() return ED.Database:GetGlobalSetting("GroupHistorySize"); end,
+			set = function(val)
+				ED.Database:SetGlobalSetting("GroupHistorySize", val);
+				ED.GroupFrame:ForEachFrame(function(frame)
+					frame.ChatBox:SetMaxLines(val);
+					frame:RefreshChat();
+				end);
+			end,
+		},
+		{
 			type = "subtitle",
 			label = L.NOTIFICATIONS_TITLE,
 			subLabel = L.GROUP_NOTIFICATIONS_HELP,
@@ -1263,7 +1281,7 @@ function Eavesdropper_SettingsMixin:OnLoad()
 	self:CreateCategory(L.ADV_FORMATTING, true, advancedFormattingOptions);
 	self:CreateCategory(L.KEYWORDS_TITLE, true, keywordsOptions);
 	self:CreateCategory(L.DEDICATED, false, dedicatedOptions);
-	self:CreateCategory(L.GROUPS, false, groupOptions);
+	self:CreateCategory(L.GROUPS, true, groupOptions);
 	self:CreateCategory(L.NOTIFICATIONS_TITLE, false, notificationsOptions);
 	self:CreateCategory(L.PROFILES_TITLE, false, profilesOptions);
 


### PR DESCRIPTION
Group Windows, up to now, shared `MaxHistory` with Main & Dedicated. This had a max of 300 lines, which can fill up quite fast in groups if you've got 10+ people talking. `GroupHistorySize` is a new global setting (10-1000, default 100) introduced for Group Windows. Other code has been updated to accept a `ChatBox`'s `MaxLines` to be set differently.

However raising the cap presented another issue that is only obvious in Group Windows. `RefreshChat` would re-gather, dedupe and sort every tracked player's history from scratch for every single refresh regardless of any actual changes. This is now handled instead by ``RebuildMergedHistory`, which only reruns when group size/filters/etc. actually changes and then caches the result in `self.mergedHistory`. The timestamp ticker and MSP burst window can just redraw that cache through `RedrawChat` which is virtually costless. Live messages will get appended straight to this cache instead of triggering a full rebuild.

During controlled testing of about ~2K gathered entries (tracked players x `GroupHistorySize`) `RebuildMergedHistory` spreads player gathering out per frame (`RunNextFrame`) instead of all trying to do it sync. This leads to adding/removing someone from a bigger Group not causing any noticeable FPS lose/freezes. With 80 unique players showing 300 max messages the old system would take my own FPS down from 72 to 40-50 for every new player added, while the new chunked version remained at ~71 which is (honestly) within margin of error and might as well be negligible. The function also keeps a counter that invalidates a rebuild when there is a newer more relevant one (think adding a player mid-chunking) and just starts anew.

Finally we introduce a flyway (schema version might still change, we'll see). This makes sure that if someone had set their history size above 100, that we use that for group windows. That way group windows won't have a lower size than main/dedicated after it is added.