### PR TITLE
Adjust Slider Pip Position

### DIFF
--- a/UI/SettingsElements.lua
+++ b/UI/SettingsElements.lua
@@ -355,6 +355,7 @@ local function CreateSlider(parent, data)
 	local _, right, label = CreateLabeledFrame(parent, data);
 
 	local widget = CreateFrame("Slider", nil, right, "MinimalSliderWithSteppersTemplate");
+	widget:SetHeight(Constants.SETTINGS.WIDGET_HEIGHT);
 	widget:SetPoint("LEFT", right, "LEFT", 0, 0);
 	widget:SetPoint("RIGHT", right, "RIGHT", -25, 0); -- leave space for RightText
 	widget:SetPoint("CENTER", right, "CENTER");


### PR DESCRIPTION
Currently (in the left image), the slider's pip is farther than the other widgets.
We adjusted that (see the right image), so it is more consistent.

<img width="568" height="164" alt="WoWScrnShot_081526_233405" src="https://github.com/user-attachments/assets/2449d499-70c7-481d-98f5-4d03fa3cd4da" />

- The slider widget's height is changed from the default `40` to ED's standard widget height `25`.
- It does not make dragging the slider/thumb difficult because the thumb's appearance still matches its actual clickable area.