### PR TITLE
Fix nil ED.Frame error in RefreshAllWindows

### DIFF
--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -159,7 +159,7 @@ local function RefreshAllWindows()
 		frame:RefreshChat(true);
 	end);
 
-	if ED.Frame:IsShown() then
+	if ED.Frame and ED.Frame:IsShown() then
 		ED.Frame:RefreshChat(true);
 	end
 end


### PR DESCRIPTION
This could happen through the `WORKFLOW_ON_LOADED` callback rarely.

From a Discord write-up:
> TRP has a `WORKFLOW_ON_LOADED` callback.
> 
> It can fire `ED.MSP.SetTRPReady` which fires `InvalidateCache` which eventually fires `ScheduleDataRefresh` before Eavesdropper might ever have created `ED.Frame`
> 
> The TRP Callback goes through `onStart` (TRP handles it), but ED waits for TRP generally.