### PR TITLE
Screenshot Helper: Hide Unwanted UI Elements and Custom Screen Background

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -317,6 +317,12 @@ stds.wow = {
 			},
 		},
 
+		C_Roleset = {
+			fields = {
+				"ApplyRolesetFilters",
+			},
+		},
+
 		C_Secrets = {
 			fields = {
 				"ShouldAurasBeSecret",
@@ -512,13 +518,6 @@ stds.wow = {
 		TimerunningUtil = {
 			fields = {
 				"AddSmallIcon",
-			},
-		},
-
-		UIModeUtil = {
-			fields = {
-				"RegisterMode",
-				"SetModeActive",
 			},
 		},
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -801,6 +801,8 @@ stds.wow = {
 		"MenuResponse",
 		"ModelFrameMixin",
 		"NamePlateDriverFrame",
+		"PlayerFrame",
+		"RogueComboPointBarFrame",
 		"SystemFont_LargeNamePlate",
 		"SystemFont_NamePlate",
 		"SystemFont_Shadow_Huge1",
@@ -811,6 +813,7 @@ stds.wow = {
 		"UIErrorsFrame",
 		"UIParent",
 		"UISpecialFrames",
+		"WarlockPowerFrame",
 		"WorldFrame",
 		"WorldMapFrame",
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -515,6 +515,13 @@ stds.wow = {
 			},
 		},
 
+		UIModeUtil = {
+			fields = {
+				"RegisterMode",
+				"SetModeActive",
+			},
+		},
+
 		"AbbreviateLargeNumbers",
 		"Ambiguate",
 		"BNGetGameAccountInfoByGUID",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -801,6 +801,7 @@ stds.wow = {
 		"ModelFrameMixin",
 		"NamePlateDriverFrame",
 		"PlayerFrame",
+		"PTR_IssueReporter",
 		"RogueComboPointBarFrame",
 		"SystemFont_LargeNamePlate",
 		"SystemFont_NamePlate",

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -259,4 +259,41 @@ function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
 	end
 end
 
+---Hide various of UI element
+function ScreenshotHelper.HideDistractions()
+	local objects = {
+		TargetFrame.TargetFrameContent.TargetFrameContentContextual,  --Target's Auras
+		PlayerFrame.PlayerFrameContent.PlayerFrameContentContextual,  --Animated Zzz, Leader Crown
+		PlayerFrame.PlayerFrameContent.PlayerFrameContentMain.StatusTexture,  --Portrait Flash
+		WarlockPowerFrame,
+		RogueComboPointBarFrame,
+	};
+
+	for _, obj in ipairs(objects) do
+		if obj then
+			obj:Hide();
+		end
+	end
+
+	local modeName = "ED_ScreenshotHelper";
+	if not ScreenshotHelper.roleSetsSet then
+		ScreenshotHelper.roleSetsSet = true;
+		UIModeUtil.RegisterMode(modeName, {
+			rolesetBlocklist = {
+				"arenaFrames",
+				"bags",
+				"buffs",
+				"cooldownViewers",
+				"encounterUI",
+				"extraAbilities",
+				"microMenu",
+				"objectives",
+				"pvp",
+				"statusBars",
+				"widgets",
+			},
+		});
+	end
+	UIModeUtil.SetModeActive(modeName, true);
+end
 ED.ScreenshotHelper = ScreenshotHelper;

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -310,7 +310,10 @@ function ScreenshotHelper.HideDistractions(bitmask)
 end
 
 ---Toggle a full-screen background ON/OFF
-function ScreenshotHelper.ToggleFullScreenBackground()
+---
+---Save the file as png under `Interface/AddOns/Eavesdropper/Assets`, the file name must start with `EDBG`
+---@param fileIndex number|string? Example: `1` for `EDBG1.png`
+function ScreenshotHelper.ToggleFullScreenBackground(fileIndex)
 	local frame = ScreenshotHelper.FullScreenBackground;
 	if not frame then
 		frame = CreateFrame("Frame", nil, UIParent);
@@ -319,9 +322,11 @@ function ScreenshotHelper.ToggleFullScreenBackground()
 		frame:SetFrameStrata("BACKGROUND");
 		frame.Texture = frame:CreateTexture();
 		frame.Texture:SetAllPoints(true);
-		frame.Texture:SetTexture("Interface/AddOns/EDBG.jpg");
 		ScreenshotHelper.FullScreenBackground = frame;
 	end
+
+	local filePath = "Interface/AddOns/Eavesdropper/Assets/EDBG%s.png";
+	frame.Texture:SetTexture(string.format(filePath, fileIndex or ""));
 	frame:SetShown(not frame:IsShown());
 end
 

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -311,7 +311,7 @@ end
 
 ---Toggle a full-screen background ON/OFF
 ---
----Save the file as png under `Interface/AddOns/Eavesdropper/Assets`, the file name must start with `EDBG`
+---Save the file as png under `Interface/AddOns/Eavesdropper/Assets/Base`, the file name must start with `EDBG`
 ---@param fileIndex number|string? Example: `1` for `EDBG1.png`
 function ScreenshotHelper.ToggleFullScreenBackground(fileIndex)
 	local frame = ScreenshotHelper.FullScreenBackground;
@@ -325,7 +325,7 @@ function ScreenshotHelper.ToggleFullScreenBackground(fileIndex)
 		ScreenshotHelper.FullScreenBackground = frame;
 	end
 
-	local filePath = "Interface/AddOns/Eavesdropper/Assets/EDBG%s.png";
+	local filePath = "Interface/AddOns/Eavesdropper/Assets/Base/EDBG%s.png";
 	frame.Texture:SetTexture(string.format(filePath, fileIndex or ""));
 	frame:SetShown(not frame:IsShown());
 end

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -275,26 +275,23 @@ function ScreenshotHelper.HideDistractions()
 		end
 	end
 
-	local modeName = "ED_ScreenshotHelper";
-	if not ScreenshotHelper.roleSetsSet then
-		ScreenshotHelper.roleSetsSet = true;
-		UIModeUtil.RegisterMode(modeName, {
-			rolesetBlocklist = {
-				"arenaFrames",
-				"bags",
-				"buffs",
-				"cooldownViewers",
-				"encounterUI",
-				"extraAbilities",
-				"microMenu",
-				"objectives",
-				"pvp",
-				"statusBars",
-				"widgets",
-			},
-		});
-	end
-	UIModeUtil.SetModeActive(modeName, true);
+	local blockedRolesets = {
+		"arenaFrames",
+		"bags",
+		"buffs",
+		"cooldownViewers",
+		"encounterUI",
+		"extraAbilities",
+		"microMenu",
+		"objectives",
+		"pvp",
+		"statusBars",
+		"widgets",
+	};
+
+	local allowedRolesets = {};
+
+	C_Roleset.ApplyRolesetFilters(blockedRolesets, allowedRolesets);
 end
 
 ---Toggle a full-screen background ON/OFF

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -260,7 +260,13 @@ function ScreenshotHelper.SetAlphaChannelMode(alphaChannelMode)
 end
 
 ---Hide various of UI element
-function ScreenshotHelper.HideDistractions()
+---@param bitmask number? Select extra UI element to hide. `ActionBar, Minimap`
+function ScreenshotHelper.HideDistractions(bitmask)
+	local optionalBlockedRolesets = {
+		"actionBars",
+		"minimap",
+	};
+
 	local objects = {
 		TargetFrame.TargetFrameContent.TargetFrameContentContextual,  --Target's Auras
 		PlayerFrame.PlayerFrameContent.PlayerFrameContentContextual,  --Animated Zzz, Leader Crown
@@ -288,6 +294,14 @@ function ScreenshotHelper.HideDistractions()
 		"statusBars",
 		"widgets",
 	};
+
+	bitmask = bitmask or 0;
+
+	for index, tag in ipairs(optionalBlockedRolesets) do
+		if bit.band(1, bit.arshift(bitmask, index - 1)) == 1 then
+			table.insert(blockedRolesets, tag);
+		end
+	end
 
 	local allowedRolesets = {};
 

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -296,4 +296,21 @@ function ScreenshotHelper.HideDistractions()
 	end
 	UIModeUtil.SetModeActive(modeName, true);
 end
+
+---Toggle a full-screen background ON/OFF
+function ScreenshotHelper.ToggleFullScreenBackground()
+	local frame = ScreenshotHelper.FullScreenBackground;
+	if not frame then
+		frame = CreateFrame("Frame", nil, UIParent);
+		frame:Hide();
+		frame:SetAllPoints(true);
+		frame:SetFrameStrata("BACKGROUND");
+		frame.Texture = frame:CreateTexture();
+		frame.Texture:SetAllPoints(true);
+		frame.Texture:SetTexture("Interface/AddOns/EDBG.jpg");
+		ScreenshotHelper.FullScreenBackground = frame;
+	end
+	frame:SetShown(not frame:IsShown());
+end
+
 ED.ScreenshotHelper = ScreenshotHelper;

--- a/UI/ScreenshotHelper.lua
+++ b/UI/ScreenshotHelper.lua
@@ -273,6 +273,7 @@ function ScreenshotHelper.HideDistractions(bitmask)
 		PlayerFrame.PlayerFrameContent.PlayerFrameContentMain.StatusTexture,  --Portrait Flash
 		WarlockPowerFrame,
 		RogueComboPointBarFrame,
+		PTR_IssueReporter,
 	};
 
 	for _, obj in ipairs(objects) do


### PR DESCRIPTION
- You can hide various UI elements, including the auras on TargetFrame, class resources, and resting Zzz on PlayerFrame.
  - Use the optional argument `bitmask` to select additional elements to hide: ActionBar, Minimap.
```lua
/run ED.ScreenshotHelper.HideDistractions(bitmask)
```

- You can set a fullscreen background so you don't have to combine everything in PS. Save your file as `Interface/AddOns/Eavesdropper/Assets/EDBG.png`  You can use the image below for testing.
  - Use the optional argument `fileIndex` to select another background file, if there is any. Example: `fileIndex = 1` chooses `EDBG1.png`.
```lua
/run ED.ScreenshotHelper.ToggleFullScreenBackground(fileIndex)
```
<img width="2048" height="2048" alt="EDBG" src="https://github.com/user-attachments/assets/b806a294-c902-4966-834b-f40c6a63f597" />
