### PR TITLE
Scope Settings widget refresh to the active tab

### DIFF
--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -728,7 +728,7 @@ function Database:SetSetting(key, value)
 	end
 
 	if ED.SettingsFrame then
-		ED.SettingsFrame:RefreshWidgets();
+		ED.SettingsFrame:RefreshCurrentPanel();
 	end
 end
 
@@ -849,7 +849,7 @@ function Database:SetGlobalSetting(key, value)
 	end
 
 	if ED.SettingsFrame then
-		ED.SettingsFrame:RefreshWidgets();
+		ED.SettingsFrame:RefreshCurrentPanel();
 	end
 end
 

--- a/UI/SettingsFrame.lua
+++ b/UI/SettingsFrame.lua
@@ -23,6 +23,7 @@ for _, fontName in ipairs(SharedMedia:List("font")) do
 end
 
 local lastSelectedTab;
+local selectedPanelIndex;
 local allWidgets = {};
 
 -- ============================================================
@@ -35,6 +36,27 @@ function Eavesdropper_SettingsMixin:RefreshWidgets()
 			widget:Refresh();
 		end
 	end
+end
+
+---Refreshes only the widgets belonging to a single panel (Views entry), not the whole Settings frame
+function Eavesdropper_SettingsMixin:RefreshPanelWidgets(panel)
+	local widgets = (panel.scrollChild and panel.scrollChild.widgets) or panel.widgets;
+	if not widgets then return; end
+
+	for _, widget in pairs(widgets) do
+		if widget.Refresh then
+			widget:Refresh();
+		end
+	end
+end
+
+---Refresh only the widgets on the currently-selected tab, which is better for single setting changes.
+---Profile-wide operations, like switch profile etc., still require the usual full RefreshWidgets.
+function Eavesdropper_SettingsMixin:RefreshCurrentPanel()
+	local panel = selectedPanelIndex and self.Views[selectedPanelIndex];
+	if not panel then return; end
+
+	self:RefreshPanelWidgets(panel);
 end
 
 -- ============================================================
@@ -97,9 +119,14 @@ function Eavesdropper_SettingsMixin:SetTab(view)
 				scroll.ScrollBar:SetShown(isSelected);
 			end
 		end
+
+		if isSelected then
+			self:RefreshPanelWidgets(panel);
+		end
 	end
 
 	lastSelectedTab = view;
+	selectedPanelIndex = index;
 end
 
 -- ============================================================
@@ -192,6 +219,9 @@ function Eavesdropper_SettingsMixin:PopulatePanel(panel, options)
 		if widget then
 			local key = widget.settingKey or (#allWidgets + 1);
 			allWidgets[key] = widget;
+
+			panel.widgets = panel.widgets or {};
+			panel.widgets[#panel.widgets + 1] = widget;
 		end
 
 		previousContainer = container;


### PR DESCRIPTION
Before:
```
Changing history size from 50 to 300::
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.289ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.642ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.592ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.434ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.833ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 3.877ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 3.985ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 5.694ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.695ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.551ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.681ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.783ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.796ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 7.757ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 9.043ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 7.631ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 7.440ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 7.914ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 7.208ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 5.505ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.379ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.441ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.364ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.337ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.348ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.384ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.363ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.386ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.395ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.257ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.342ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.435ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 4.211ms
[02:26:39] [ED perf] RefreshWidgets: 84 widgets, 5.437ms

Changing a dropdown twice.
[02:26:55] [ED perf] RefreshWidgets: 84 widgets, 5.479ms
[02:26:57] [ED perf] RefreshWidgets: 84 widgets, 5.392ms

Toggle and untoggle a checkbox
[02:26:59] [ED perf] RefreshWidgets: 84 widgets, 4.686ms
[02:26:59] [ED perf] RefreshWidgets: 84 widgets, 4.622ms
```

After (General tab):
```
Dragging history size 50 - 300:
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.535ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.548ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.610ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.560ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.564ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.540ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.530ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.545ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.550ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.553ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.550ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.553ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.553ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.553ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.561ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.540ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.542ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.540ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.522ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.538ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.549ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.528ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.548ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.530ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.549ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.557ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.602ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.529ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.520ms
[02:28:35] [ED perf] RefreshCurrentPanel: 12 widgets, 0.525ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.605ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 1.308ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.562ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.826ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.561ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.561ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.565ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.567ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.574ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.561ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.524ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.634ms
[02:28:36] [ED perf] RefreshCurrentPanel: 12 widgets, 0.592ms

Checkbox on and off
[02:29:01] [ED perf] RefreshCurrentPanel: 12 widgets, 1.512ms
[02:29:02] [ED perf] RefreshCurrentPanel: 12 widgets, 1.529ms

Dropdown change twice
[02:29:03] [ED perf] RefreshCurrentPanel: 12 widgets, 0.523ms
[02:29:03] [ED perf] RefreshCurrentPanel: 12 widgets, 0.636ms
```