### PR TITLE
Fix lost 's/, prefix on emotes, drop broken filter-reprocessing loop

### DIFF
--- a/Core/ChatHandler.lua
+++ b/Core/ChatHandler.lua
@@ -7,13 +7,45 @@ local Constants = ED.Constants;
 ---@class EavesdropperChatHandler
 local ChatHandler = {};
 
+-- TRP3 strips a raw "'s "/", " emote prefix to reinsert it beside its own colored name.
+-- The filter below captures it first, keyed by lineID, so ChatFrameFilter can restore it.
+local pendingEmotePrefixes = {};
+
+---GetEmotePrefix Returns the raw "'s "/", " prefix of an emote message, if present.
+---@param message string
+---@return string?
+local function GetEmotePrefix(message)
+	if message:sub(1, 3) == "'s " then
+		return message:sub(1, 3);
+	elseif message:sub(1, 2) == ", " then
+		return message:sub(1, 2);
+	end
+end
+
+-- Registered at file load rather than in Init(), so this runs ahead of TRP3's own
+-- CHAT_MSG_EMOTE filter, which TRP3 only registers on PLAYER_LOGIN.
+if ChatFrameUtil and type(ChatFrameUtil.AddMessageEventFilter) == "function" then
+	ChatFrameUtil.AddMessageEventFilter("CHAT_MSG_EMOTE", function(_, _, ...)
+		local message = select(1, ...);
+		local lineID  = select(11, ...);
+
+		if not message or not canaccessvalue(message) or not lineID then return; end
+
+		local prefix = GetEmotePrefix(message);
+		if not prefix then return; end
+
+		pendingEmotePrefixes[lineID] = prefix;
+		C_Timer.After(5, function() pendingEmotePrefixes[lineID] = nil; end);
+	end);
+end
+
 ---ChatFrameFilter Core Blizzard chat message filter
 ---@param chatFrame table Blizzard chat frame
 ---@param event string Chat event
 ---@param ... any
 ---@return boolean?
 function ChatHandler:ChatFrameFilter(chatFrame, event, ...)
-	local message, sender, language, _, _, _, _, _, channel, _, _, guid = ...;
+	local message, sender, language, _, _, _, _, _, channel, _, lineID, guid = ...;
 
 	if not message or not canaccessvalue(message) then return; end
 
@@ -32,40 +64,12 @@ function ChatHandler:ChatFrameFilter(chatFrame, event, ...)
 	end
 	]]
 
-	-- Apply Blizzard chat filters.
-	local filters = ChatFrameUtil and ChatFrameUtil.GetMessageEventFilters(event);
-	if filters and message then
-		local skipFilters = message:sub(1, 3) == "|| ";
-
-		if not skipFilters then
-			for filterFunc in next, filters do
-				if type(filterFunc) == "function" then
-					local filtered = {filterFunc(chatFrame, event, ...)};
-					if filtered[1] then
-						-- Fully filtered
-						return;
-					elseif type(filtered[2]) == "string" then
-						-- Modified message
-						local newMessage = filtered[2];
-
-						-- Preserve TRP emote edge-cases
-						if event == "CHAT_MSG_EMOTE" then
-							local firstTwoOrig = message:sub(1, 2);
-							local firstTwoNew  = newMessage:sub(1, 2);
-							if (firstTwoOrig == "'s" and firstTwoNew ~= "'s")
-							or (firstTwoOrig == ", " and firstTwoNew ~= ", ") then
-								break;
-							end
-						end
-
-						message  = newMessage;
-						sender   = filtered[3];
-						language = filtered[4];
-						channel  = filtered[10];
-						guid     = filtered[13];
-					end
-				end
-			end
+	-- Restore a "'s "/", " prefix stripped upstream (e.g. by TRP3's emote filter).
+	if event == "CHAT_MSG_EMOTE" and lineID and pendingEmotePrefixes[lineID] then
+		local prefix = pendingEmotePrefixes[lineID];
+		pendingEmotePrefixes[lineID] = nil;
+		if not GetEmotePrefix(message) then
+			message = prefix .. message;
 		end
 	end
 

--- a/Core/ChatHandler.lua
+++ b/Core/ChatHandler.lua
@@ -44,7 +44,7 @@ end
 ---@param event string Chat event
 ---@param ... any
 ---@return boolean?
-function ChatHandler:ChatFrameFilter(chatFrame, event, ...)
+function ChatHandler:ChatFrameFilter(chatFrame, event, ...) -- luacheck: no unused (chatFrame)
 	local message, sender, language, _, _, _, _, _, channel, _, lineID, guid = ...;
 
 	if not message or not canaccessvalue(message) then return; end


### PR DESCRIPTION
I am explicitly not tagging this as 0.6.0 because I don't know if I'll have it tested in time (so testing is welcome).

Below is a list of stuff to test, see if stuff broke.. Maybe?

Main stuff:

* [x] `/me 's ear twitches.` displays and stores as `"Name's ear twitches."` with no space before `'s`
* [x] `/me , feeling a great disturbance.` displays and stores as `"Name, feeling a great disturbance."` with no space before `,`
* [x] Send both above back-to-back quickly to confirm prefixes do not get mixed between messages
* [x] Check both tests in the Dedicated Frame and Group Frame for that character

Check Some custom and Blizzard emotes:

* [x] `/me waves.` displays as `"Name waves."`
* [x] `/wave` remains unchanged

Check TRP stuff:

* [x] `((this is OOC))` in `/s` or `/e` still gets TRP OOC coloring
* [x] TRP NPC talk as an emote still resolves to the NPC name correctly
* [x] TRP chat links still render and can be clicked

Check basically every chat type and WoW's abuse || thingy (idk why it exists, to stop people abusing colors?):

* [x] `/s`, `/y`, `/p`, `/g` messages store and display normally
* [x] `/s || some text` stores literally as typed. WoW doubling `|` to `||` is expected

Try some checks without TRP running:

* [x] Disable TRP, `/reload`, and repeat the `'s` and `,` emote tests

For good measure:

* [x] `/reload` and repeat one `'s` test to confirm the fix survives a reload
