### PR TITLE
Add pre-commit to project (VS Code support)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+exclude: ^(Libs/TaintLess/.*|Locales/.{4}\.lua)$
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: check-yaml
+
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: 3.11.1
+    hooks:
+      - id: editorconfig-checker
+        alias: ec
+        exclude: ^(Locales/.*\.lua|UI/ChangelogMarkdown\.lua)$
+        types: []
+        types_or: [lua, shell, xml]
+
+  - repo: local
+    hooks:
+      - id: luacheck
+        name: check lua
+        entry: luacheck -q
+        language: system
+        types: [lua]
+        require_serial: true
+
+      - id: xml
+        name: check xml
+        entry: python .github/scripts/validate_xml.py
+        language: python
+        additional_dependencies:
+          - lxml~=6.1
+        types: [xml]
+        exclude: ^(Bindings\.xml|.*\.xsd)$
+        require_serial: true


### PR DESCRIPTION
Requirements:
- install pre-commit
- install luacheck
- install python
- install the lxml from pip
- make sure pre-commit, luacheck, and python are all on path

`pre-commit run -a` will then run the checks against all files in the repo, and `pre-commit install` will set up the hooks in .git to run checks on each commit

Commits can skip pre-commit checks if you explicitly `git commit -n` them