### PR TITLE
Add Eavesdrop on / Eavesdrop Group to the main and dedicated window menus

### DIFF
--- a/Core/Config.lua
+++ b/Core/Config.lua
@@ -108,6 +108,20 @@ function Config.ShowConfigMenu(frame, mode)
 		filter:CreateTitle(L.FILTER .. " " .. MAIN_MENU);
 		ED.ChatFilters:GenerateFilterListMenu(frame, filter);
 
+		-- Eavesdrop on / Eavesdrop Group: always shown, disabled without an eavesdropped target.
+		-- A dedicated window always has one, so it only gets Eavesdrop Group.
+		if (mode == nil or mode == "dedicated") and ED.UnitPopups then
+			local sender = frame.eavesdropped_player;
+			local guid = frame.eavesdropped_player_guid;
+
+			if mode == nil and ED.Database:GetGlobalSetting("DedicatedWindows") then
+				ED.UnitPopups.CreateEavesdropOnButton(rootDescription, sender, guid);
+			end
+			if ED.Database:GetGlobalSetting("GroupWindows") then
+				ED.UnitPopups.CreateEavesdropGroupButton(rootDescription, sender, guid);
+			end
+		end
+
 		-- No other frame ever displays entry.mn, so this is Mentions-only.
 		if mode == "mentions" then
 			local mentionTypes = rootDescription:CreateButton(L.MENTIONS_REASON_FILTER);

--- a/Modules/UnitPopups/UnitPopups.lua
+++ b/Modules/UnitPopups/UnitPopups.lua
@@ -151,37 +151,57 @@ local function CreateOpenCharacterEavesdropButton(menuDescription, contextData)
 		return;
 	end
 
-	local function OnClick(contextData) -- luacheck: no redefined
-		local sender, guid = resolveCharacterData(contextData);
+	local sender, guid = resolveCharacterData(contextData);
+	local elementDescription = UnitPopups.CreateEavesdropOnButton(menuDescription, sender, guid);
+	elementDescription:SetData(contextData);
+	return elementDescription;
+end
+
+---Shared by the unit popup menu and Config.lua's window menu.
+---@param menuDescription table
+---@param sender string?
+---@param guid string?
+---@return table elementDescription
+function UnitPopups.CreateEavesdropOnButton(menuDescription, sender, guid)
+	local elementDescription = menuDescription:CreateButton(L.UNIT_POPUPS_EAVESDROP_ON);
+	ED.Utils.SetMenuTooltip(elementDescription, L.UNIT_POPUPS_EAVESDROP_ON_HELP);
+	elementDescription:SetResponder(function()
 		if sender then
 			ED.PlayerCache:InsertAndRetrieve(sender, guid);
 			ED.DedicatedFrame:AddFrame(sender);
 		end
-	end
-
-	-- Resolve sender once for existing dedicated window check
-	local sender = resolveCharacterData(contextData);
-
-	local elementDescription = menuDescription:CreateButton(L.UNIT_POPUPS_EAVESDROP_ON);
-	ED.Utils.SetMenuTooltip(elementDescription, L.UNIT_POPUPS_EAVESDROP_ON_HELP);
-	elementDescription:SetResponder(OnClick);
-	elementDescription:SetData(contextData);
-	if ED.DedicatedFrame:FrameExists(sender) then
+	end);
+	if not sender or ED.DedicatedFrame:FrameExists(sender) then
 		elementDescription:SetEnabled(false);
 	end
 	return elementDescription;
 end
 
----Shared UI construction for group menu buttons; called by both group menu factories.
+---Shared by the unit popup menu and Config.lua's window menu.
 ---@param menuDescription table
----@param contextData table
 ---@param sender string?
----@param OnClick function
+---@param guid string?
 ---@return table elementDescription
-local function BuildGroupMenu(menuDescription, contextData, sender, OnClick)
+function UnitPopups.CreateEavesdropGroupButton(menuDescription, sender, guid)
 	local elementDescription = menuDescription:CreateButton(L.UNIT_POPUPS_EAVESDROP_GROUP);
 	elementDescription:CreateTitle(L.UNIT_POPUPS_EAVESDROP_GROUP .. " " .. MAIN_MENU);
 	ED.Utils.SetMenuTooltip(elementDescription, L.UNIT_POPUPS_EAVESDROP_GROUP_HELP);
+
+	if not sender then
+		elementDescription:SetEnabled(false);
+		return elementDescription;
+	end
+
+	local function OnClick(targetFrame, hasSender)
+		ED.PlayerCache:InsertAndRetrieve(sender, guid);
+		if targetFrame and hasSender then
+			targetFrame:RemovePlayer(sender);
+		elseif targetFrame and not hasSender then
+			targetFrame:AddPlayer(sender);
+		else
+			ED.GroupFrame:AddFrame(sender);
+		end
+	end
 
 	local groupWindows = ED.GroupFrame:GetGroupWindows(sender);
 	if groupWindows then
@@ -204,7 +224,6 @@ local function BuildGroupMenu(menuDescription, contextData, sender, OnClick)
 		OnClick();
 	end);
 
-	elementDescription:SetData(contextData);
 	return elementDescription;
 end
 
@@ -217,41 +236,19 @@ local function CreateBattleNetEavesdropGroupMenu(menuDescription, contextData)
 		return;
 	end
 
-	local function OnClick(targetFrame, hasSender) -- luacheck: no redefined
-		local sender, guid = GetBattleNetCharacterFullName(gameAccountInfo);
-		if sender then
-			ED.PlayerCache:InsertAndRetrieve(sender, guid);
-			if targetFrame and hasSender then
-				targetFrame:RemovePlayer(sender);
-			elseif targetFrame and not hasSender then
-				targetFrame:AddPlayer(sender);
-			else
-				ED.GroupFrame:AddFrame(sender);
-			end
-		end
-	end
-
-	return BuildGroupMenu(menuDescription, contextData, GetBattleNetCharacterFullName(gameAccountInfo), OnClick);
+	local sender, guid = GetBattleNetCharacterFullName(gameAccountInfo);
+	local elementDescription = UnitPopups.CreateEavesdropGroupButton(menuDescription, sender, guid);
+	elementDescription:SetData(contextData);
+	return elementDescription;
 end
 
 local function CreateEavesdropGroupMenu(menuDescription, contextData)
 	if not ED.Database:GetGlobalSetting("GroupWindows") or not ED.Database:GetGlobalSetting("GroupWindowsUnitPopups") then return; end
 
-	local function OnClick(targetFrame, hasSender) -- luacheck: no redefined
-		local sender, guid = resolveCharacterData(contextData);
-		if sender then
-			ED.PlayerCache:InsertAndRetrieve(sender, guid);
-			if targetFrame and hasSender then
-				targetFrame:RemovePlayer(sender);
-			elseif targetFrame and not hasSender then
-				targetFrame:AddPlayer(sender);
-			else
-				ED.GroupFrame:AddFrame(sender);
-			end
-		end
-	end
-
-	return BuildGroupMenu(menuDescription, contextData, resolveCharacterData(contextData), OnClick);
+	local sender, guid = resolveCharacterData(contextData);
+	local elementDescription = UnitPopups.CreateEavesdropGroupButton(menuDescription, sender, guid);
+	elementDescription:SetData(contextData);
+	return elementDescription;
 end
 
 ---Find the native Copy Character Name button already inserted into rootDescription


### PR DESCRIPTION
"That's all folks!" - Looney Tunes
!["That's all folks!" - Looney Tunes](https://static2.klipy.com/ii/e293a233a303a98e471f78d04e13a1b0/0b/cb/cRK4tajq.gif)


The last feature to be added, as it should have been in originally when we upgraded the window menus to be 'easier to manage'.