### PR TITLE
Resolve emote targets & roll senders via live units or other paths

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -603,6 +603,7 @@ stds.wow = {
 		"GetMouseFoci",
 		"GetMouseFocus",
 		"GetNormalizedRealmName",
+		"GetNumGroupMembers",
 		"GetNumLanguages",
 		"GetPlayerInfoByGUID",
 		"GetRealmName",

--- a/Core/AdvancedFormatter.lua
+++ b/Core/AdvancedFormatter.lua
@@ -40,11 +40,14 @@ local function CreateChatName(event, _, _, sender, _, _, _, _, _, _, _, _, _, gu
 		sender = ED.PlayerCache:GetSenderDataFromGUID(guid) or sender;
 	end
 
-	-- nil if secrets, guard against that
+	-- InsertAndRetrieve returns nil for secret players; drop guid too rather than keep the
+	-- rejected value around.
 	local newSender, newGuid = ED.PlayerCache:InsertAndRetrieve(sender, guid);
 	if newSender then
 		sender = newSender;
 		guid = newGuid;
+	else
+		guid = nil;
 	end
 
 	local entry = {

--- a/Core/AdvancedFormatter.lua
+++ b/Core/AdvancedFormatter.lua
@@ -125,10 +125,14 @@ function AdvancedFormatter:HandleChecks(chatFrame, event, message, sender, ...) 
 		msgSender = ED.PlayerCache:GetSenderDataFromGUID(guid) or msgSender;
 	end
 
+	-- InsertAndRetrieve returns nil for secret players; drop guid too rather than keep the
+	-- rejected value around.
 	local newMsgSender, newGuid = ED.PlayerCache:InsertAndRetrieve(msgSender, guid);
 	if newMsgSender then
 		msgSender = newMsgSender;
 		guid = newGuid;
+	else
+		guid = nil;
 	end
 
 	local entry = {

--- a/Core/AdvancedFormatter.lua
+++ b/Core/AdvancedFormatter.lua
@@ -101,6 +101,11 @@ function AdvancedFormatter:HandleChecks(chatFrame, event, message, sender, ...) 
 		msgSender, _, _, _ = ED.Utils.GetRollData(msgText);
 		if msgSender then
 			event = "ROLL";
+			-- Rolls carry no GUID from Blizzard, but a roll from another player is only ever visible
+			-- while grouped with them, so the roster can resolve their full identity.
+			local resolvedSender, rollGuid = ED.PlayerCache:ResolveLiveUnitByName(msgSender);
+			msgSender = resolvedSender or msgSender;
+			guid = guid or rollGuid;
 		else
 			return;
 		end

--- a/Core/ChatFormatter.lua
+++ b/Core/ChatFormatter.lua
@@ -312,13 +312,15 @@ end
 local function FormatTextEmoteTargetWithRPName(entry, msgText, forceDisplayMode)
 	local sender, guid = entry.tn, entry.tg;
 
-	if not sender or not guid then
+	if not guid then
 		local _, liveSender, senderEntry = ED.PlayerCache:ResolveEmoteSender(entry.m, entry.s);
-		sender = sender or liveSender;
-		guid = guid or (senderEntry and senderEntry.guid);
 
-		if liveSender then
-			entry.tn = entry.tn or liveSender;
+		-- Only trust a freshly resolved GUID for the same target already frozen (or nothing
+		-- frozen yet); a different name isn't safe to pair with the frozen one.
+		if liveSender and (not sender or liveSender == sender) then
+			sender = liveSender;
+			guid = senderEntry and senderEntry.guid;
+			entry.tn = sender;
 			entry.tg = guid;
 		end
 	end

--- a/Core/ChatFormatter.lua
+++ b/Core/ChatFormatter.lua
@@ -387,7 +387,9 @@ function ChatFormatter:GetFormattedName(entry, forceDisplayMode)
 		applyRPName = useRPName and useRPNameForTargets;
 	end
 
-	if not firstName or not useRPName then
+	-- applyRPName (not useRPName): a per-event toggle (rolls/targets) being off must still
+	-- fall back to the bare name to mirror Blizzard not showing realms.
+	if not firstName or not applyRPName then
 		name = ED.Utils.StripRealmSuffix(name);
 	end
 

--- a/Core/ChatFormatter.lua
+++ b/Core/ChatFormatter.lua
@@ -310,10 +310,23 @@ end
 ---@param forceDisplayMode number? Overrides the profile NameDisplayMode when set.
 ---@return string
 local function FormatTextEmoteTargetWithRPName(entry, msgText, forceDisplayMode)
-	local bareName, sender, senderEntry = ED.PlayerCache:ResolveEmoteSender(entry.m, entry.s);
-	if not bareName or not sender then return msgText; end
+	local sender, guid = entry.tn, entry.tg;
 
-	local targetFullName, targetFirstName, targetNameColor = ED.MSP.TryGetMSPData(sender, senderEntry.guid);
+	if not sender or not guid then
+		local _, liveSender, senderEntry = ED.PlayerCache:ResolveEmoteSender(entry.m, entry.s);
+		sender = sender or liveSender;
+		guid = guid or (senderEntry and senderEntry.guid);
+
+		if liveSender then
+			entry.tn = entry.tn or liveSender;
+			entry.tg = guid;
+		end
+	end
+
+	if not sender then return msgText; end
+	local bareName = sender:match("^([^%-]+)");
+
+	local targetFullName, targetFirstName, targetNameColor = ED.MSP.TryGetMSPData(sender, guid);
 	if not targetFullName then return msgText; end
 
 	local nameDisplayMode = forceDisplayMode or ED.Database:GetSetting("NameDisplayMode");

--- a/Core/ChatHandler.lua
+++ b/Core/ChatHandler.lua
@@ -58,8 +58,8 @@ function ChatHandler:ChatFrameFilter(chatFrame, event, ...) -- luacheck: no unus
 		if ED.Constants.IGNORED_CHANNELS[lower] then return; end
 	end
 
+	-- Debug in case the ChatFrame arguments ever change.
 	--[[
-	Debug in case the ChatFrame arguments ever change.
 	local args = {...};
 	print("Event:", event);
 	for i, v in ipairs(args) do

--- a/Core/ChatHandler.lua
+++ b/Core/ChatHandler.lua
@@ -80,7 +80,10 @@ function ChatHandler:ChatFrameFilter(chatFrame, event, ...) -- luacheck: no unus
 	if event == "CHAT_MSG_SYSTEM" then
 		local rollSender = ED.Utils.GetRollData(message);
 		if rollSender then
-			ED.ChatHistory:AddEntry("ROLL", rollSender, message);
+			-- Rolls carry no GUID from Blizzard, but a roll from another player is only ever visible
+			-- while grouped with them, so the roster can resolve their full identity.
+			local resolvedSender, rollGuid = ED.PlayerCache:ResolveLiveUnitByName(rollSender);
+			ED.ChatHistory:AddEntry("ROLL", resolvedSender or rollSender, message, nil, rollGuid);
 		end
 	else
 		ED.ChatHistory:AddEntry(event, sender, message, language, guid, channel);

--- a/Core/ChatHistory.lua
+++ b/Core/ChatHistory.lua
@@ -13,6 +13,8 @@
 ---@field sm string? Split Marker (so old messages don't break on changing them).
 ---@field mn EavesdropperMentionReason? Mention reason (stored as a bitmask); nil when the message was not aimed at the player.
 ---@field test boolean? For debug messages, true for test and generally nil otherwise.
+---@field tn string? Emote target's Name-Realm, frozen once resolved.
+---@field tg string? Emote target's GUID, frozen alongside tn.
 
 ---@class EavesdropperChatHistory
 ---@field history table<string, EavesdropperChatEntry[]> Per-sender chat history
@@ -419,6 +421,15 @@ function ChatHistory:AddEntry(event, sender, message, language, guid, channel)
 		g = guid, -- Can be tied to Companion Information.
 		sm = false,
 	};
+
+	-- Freeze the target's identity while it's still live.
+	if event == "CHAT_MSG_TEXT_EMOTE" then
+		local _, targetSender, targetEntry = ED.PlayerCache:ResolveEmoteSender(entry.m, entry.s);
+		if targetSender then
+			entry.tn = targetSender;
+			entry.tg = targetEntry and targetEntry.guid;
+		end
+	end
 
 	if channel then
 		local c = channel:match("^%S+");

--- a/Core/ChatHistory.lua
+++ b/Core/ChatHistory.lua
@@ -395,11 +395,14 @@ function ChatHistory:AddEntry(event, sender, message, language, guid, channel)
 		sender = ED.PlayerCache:GetSenderDataFromGUID(guid) or sender;
 	end
 
-	-- InsertAndRetrieve returns nil for secret players; guard against that.
+	-- InsertAndRetrieve returns nil for secret players; drop guid too rather than keep the
+	-- rejected value around.
 	local newSender, newGuid = ED.PlayerCache:InsertAndRetrieve(sender, guid);
 	if newSender then
 		sender = newSender;
 		guid = newGuid;
+	else
+		guid = nil;
 	end
 
 	self.history[sender] = self.history[sender] or {};

--- a/Core/Events.lua
+++ b/Core/Events.lua
@@ -21,6 +21,7 @@ Events:RegisterEvent("PLAYER_REGEN_ENABLED");
 Events:RegisterEvent("PLAYER_FOCUS_CHANGED");
 Events:RegisterEvent("PLAYER_TARGET_CHANGED");
 Events:RegisterEvent("UPDATE_MOUSEOVER_UNIT");
+Events:RegisterEvent("GROUP_ROSTER_UPDATE");
 
 ---Fired when combat begins (regen disabled). Handles frame visibility if HideInCombat is set.
 function Events:PLAYER_REGEN_DISABLED()
@@ -59,6 +60,11 @@ function Events:UPDATE_MOUSEOVER_UNIT()
 	or targetPriority == Enums.TARGET_PRIORITY.FOCUS_ONLY then return; end
 
 	ED.Magnifier:StartUpdateCheck();
+end
+
+---Fired when group composition changes.
+function Events:GROUP_ROSTER_UPDATE()
+	ED.PlayerCache:BackfillFromGroupRoster();
 end
 
 ED.Events = Events;

--- a/Core/PlayerCache.lua
+++ b/Core/PlayerCache.lua
@@ -255,32 +255,58 @@ end
 ---@type string[]
 local LIVE_TARGET_UNITS = { "target", "mouseover", "focus" };
 
+---Returns a unit's Name-Realm/GUID, or nil if it isn't a resolvable player.
+---Rejects GetUnitName's own-name fallback (fires pre-sync) so it isn't paired with a different unit's GUID.
+---@param unit string
+---@param ownName string?
+---@return string? sender
+---@return string? guid
+local function ResolveUnitSenderGuid(unit, ownName)
+	if not UnitExists(unit) or not UnitIsPlayer(unit) then return; end
+
+	local guid = UnitGUID(unit);
+	local sender = Utils.GetUnitName(unit);
+	if not sender then return; end
+	if guid ~= ED.Globals.player_guid and sender == ownName then return; end
+
+	return sender, guid;
+end
+
 ---Covers emote targets that were never cached from chat activity but are still visible in-world.
 ---@return {sender:string, guid:string?}[]
 local function GetLiveTargetUnits()
 	local units = {};
+	local ownName = Utils.GetUnitName();
 
 	for _, unit in ipairs(LIVE_TARGET_UNITS) do
-		if UnitExists(unit) and UnitIsPlayer(unit) then
-			local sender = Utils.GetUnitName(unit);
-			if sender then
-				units[#units + 1] = { sender = sender, guid = UnitGUID(unit) };
-			end
+		local sender, guid = ResolveUnitSenderGuid(unit, ownName);
+		if sender then
+			units[#units + 1] = { sender = sender, guid = guid };
 		end
 	end
 
 	local groupPrefix = IsInRaid() and "raid" or "party";
 	for i = 1, GetNumGroupMembers() do
-		local unit = groupPrefix .. i;
-		if UnitExists(unit) and UnitIsPlayer(unit) then
-			local sender = Utils.GetUnitName(unit);
-			if sender then
-				units[#units + 1] = { sender = sender, guid = UnitGUID(unit) };
-			end
+		local sender, guid = ResolveUnitSenderGuid(groupPrefix .. i, ownName);
+		if sender then
+			units[#units + 1] = { sender = sender, guid = guid };
 		end
 	end
 
 	return units;
+end
+
+---Finds a live unit whose bare name matches, from a precomputed unit list.
+---@param units {sender:string, guid:string?}[]
+---@param bareName string
+---@return string? sender
+---@return string? guid
+local function FindUnitByName(units, bareName)
+	for _, unitData in ipairs(units) do
+		if unitData.sender:match("^" .. bareName .. "%-") then
+			return unitData.sender, unitData.guid;
+		end
+	end
 end
 
 ---Resolves a bare character name to a live Name-Realm/GUID via target/mouseover/focus/group.
@@ -289,12 +315,7 @@ end
 ---@return string? guid
 function PlayerCache:ResolveLiveUnitByName(bareName)
 	if not bareName or bareName == "" then return; end
-
-	for _, unitData in ipairs(GetLiveTargetUnits()) do
-		if unitData.sender:match("^" .. bareName .. "%-") then
-			return unitData.sender, unitData.guid;
-		end
-	end
+	return FindUnitByName(GetLiveTargetUnits(), bareName);
 end
 
 ---Upgrades any bare-name bySender entries that match a current group member, instead of waiting
@@ -306,9 +327,11 @@ function PlayerCache:BackfillFromGroupRoster()
 			bareNames[#bareNames + 1] = sender;
 		end
 	end
+	if #bareNames == 0 then return; end
 
+	local liveUnits = GetLiveTargetUnits();
 	for _, bareName in ipairs(bareNames) do
-		local sender, guid = self:ResolveLiveUnitByName(bareName);
+		local sender, guid = FindUnitByName(liveUnits, bareName);
 		if sender then
 			self:InsertAndRetrieve(sender, guid);
 		end

--- a/Core/PlayerCache.lua
+++ b/Core/PlayerCache.lua
@@ -247,16 +247,25 @@ function PlayerCache:GetSenderDataFromGUID(guid)
 end
 
 ---Returns true if bareName appears in message as a standalone whole word.
+---Checks every occurrence, since an earlier one can be a substring of a longer name (e.g. "Ann" in "Annabelle").
 ---@param message string
 ---@param bareName string
 ---@return boolean
 local function IsWholeWordMatch(message, bareName)
-	local s, e = message:find(bareName, 1, true);
-	if not s then return false; end
+	local searchFrom = 1;
 
-	local before = message:sub(s - 1, s - 1);
-	local after  = message:sub(e + 1, e + 1);
-	return (before == "" or before:match("[%s%p]") ~= nil) and (after == "" or after:match("[%s%p]") ~= nil);
+	while true do
+		local s, e = message:find(bareName, searchFrom, true);
+		if not s then return false; end
+
+		local before = message:sub(s - 1, s - 1);
+		local after  = message:sub(e + 1, e + 1);
+		if (before == "" or before:match("[%s%p]") ~= nil) and (after == "" or after:match("[%s%p]") ~= nil) then
+			return true;
+		end
+
+		searchFrom = e + 1;
+	end
 end
 
 ---Unit tokens checked, alongside the current group roster, when a target has no PlayerCache entry.

--- a/Core/PlayerCache.lua
+++ b/Core/PlayerCache.lua
@@ -283,6 +283,20 @@ local function GetLiveTargetUnits()
 	return units;
 end
 
+---Resolves a bare character name to a live Name-Realm/GUID via target/mouseover/focus/group.
+---@param bareName string
+---@return string? sender
+---@return string? guid
+function PlayerCache:ResolveLiveUnitByName(bareName)
+	if not bareName or bareName == "" then return; end
+
+	for _, unitData in ipairs(GetLiveTargetUnits()) do
+		if unitData.sender:match("^" .. bareName .. "%-") then
+			return unitData.sender, unitData.guid;
+		end
+	end
+end
+
 ---Resolves an emote's target to a sender by bare-name match, falling back to live units when
 ---PlayerCache has no entry (i.e. the target never spoke).
 ---@param message string

--- a/Core/PlayerCache.lua
+++ b/Core/PlayerCache.lua
@@ -94,6 +94,20 @@ function PlayerCache:LoadFromSaved(cache, ttl)
 	self:PruneOldEntries(ttl);
 end
 
+---Removes a byTime slot and its sortedTimes entry, if any.
+---@param time number?
+local function RemoveByTimeSlot(time)
+	if not time then return; end
+
+	PlayerCache.byTime[time] = nil;
+	for i = #sortedTimes, 1, -1 do
+		if sortedTimes[i] == time then
+			tremove(sortedTimes, i);
+			break;
+		end
+	end
+end
+
 ---Inserts or updates a sender  <-> GUID mapping across all three indices and persists to CharDB.
 ---@param sender string
 ---@param guid string?
@@ -139,15 +153,7 @@ function PlayerCache:InsertAndRetrieve(sender, guid)
 
 	-- Remove the old byTime slot for this sender before reinserting.
 	local oldEntry = self.bySender[sender];
-	if oldEntry and oldEntry.time then
-		self.byTime[oldEntry.time] = nil;
-		for i = #sortedTimes, 1, -1 do
-			if sortedTimes[i] == oldEntry.time then
-				tremove(sortedTimes, i);
-				break;
-			end
-		end
-	end
+	RemoveByTimeSlot(oldEntry and oldEntry.time);
 
 	-- Inherit guid from existing entry if none was passed in
 	if not guid and oldEntry then
@@ -157,6 +163,8 @@ function PlayerCache:InsertAndRetrieve(sender, guid)
 	-- Evict any bare-name entry now that we have the full Name-Realm.
 	if Utils.HasRealmSuffix(sender) then
 		local bareName = Utils.StripRealmSuffix(sender);
+		local bareEntry = self.bySender[bareName];
+		RemoveByTimeSlot(bareEntry and bareEntry.time);
 		self.bySender[bareName] = nil;
 	end
 

--- a/Core/PlayerCache.lua
+++ b/Core/PlayerCache.lua
@@ -297,6 +297,24 @@ function PlayerCache:ResolveLiveUnitByName(bareName)
 	end
 end
 
+---Upgrades any bare-name bySender entries that match a current group member, instead of waiting
+---for their next chat message. Run on login and roster changes.
+function PlayerCache:BackfillFromGroupRoster()
+	local bareNames = {};
+	for sender in pairs(self.bySender) do
+		if not Utils.HasRealmSuffix(sender) then
+			bareNames[#bareNames + 1] = sender;
+		end
+	end
+
+	for _, bareName in ipairs(bareNames) do
+		local sender, guid = self:ResolveLiveUnitByName(bareName);
+		if sender then
+			self:InsertAndRetrieve(sender, guid);
+		end
+	end
+end
+
 ---Resolves an emote's target to a sender by bare-name match, falling back to live units when
 ---PlayerCache has no entry (i.e. the target never spoke).
 ---@param message string

--- a/Core/PlayerCache.lua
+++ b/Core/PlayerCache.lua
@@ -346,8 +346,8 @@ function PlayerCache:BackfillFromGroupRoster()
 	end
 end
 
----Resolves an emote's target to a sender by bare-name match, falling back to live units when
----PlayerCache has no entry (i.e. the target never spoke).
+---Resolves an emote's target to a sender by bare-name match, preferring the most recently seen
+---match, and falling back to live units when PlayerCache has no entry (i.e. the target never spoke).
 ---@param message string
 ---@param sourceSender string? Full sender name or Name-Realm
 ---@return string? bareName
@@ -361,9 +361,10 @@ function PlayerCache:ResolveEmoteSender(message, sourceSender)
 		sourceBare = sourceSender:match("^([^%-]+)");
 	end
 
-	for _, data in pairs(self.byTime) do
-		local sender = data.sender;
-		if sender then
+	for _, t in ipairs(sortedTimes) do
+		local data = self.byTime[t];
+		if data and data.sender then
+			local sender = data.sender;
 			local bareName = sender:match("^([^%-]+)");
 
 			-- Skip the emote's own sender (both bare and full comparison).

--- a/Core/PlayerCache.lua
+++ b/Core/PlayerCache.lua
@@ -238,7 +238,53 @@ function PlayerCache:GetSenderDataFromGUID(guid)
 	return sender;
 end
 
----Scans byTime entries to find a sender whose bare name appears as a whole word in the message.
+---Returns true if bareName appears in message as a standalone whole word.
+---@param message string
+---@param bareName string
+---@return boolean
+local function IsWholeWordMatch(message, bareName)
+	local s, e = message:find(bareName, 1, true);
+	if not s then return false; end
+
+	local before = message:sub(s - 1, s - 1);
+	local after  = message:sub(e + 1, e + 1);
+	return (before == "" or before:match("[%s%p]") ~= nil) and (after == "" or after:match("[%s%p]") ~= nil);
+end
+
+---Unit tokens checked, alongside the current group roster, when a target has no PlayerCache entry.
+---@type string[]
+local LIVE_TARGET_UNITS = { "target", "mouseover", "focus" };
+
+---Covers emote targets that were never cached from chat activity but are still visible in-world.
+---@return {sender:string, guid:string?}[]
+local function GetLiveTargetUnits()
+	local units = {};
+
+	for _, unit in ipairs(LIVE_TARGET_UNITS) do
+		if UnitExists(unit) and UnitIsPlayer(unit) then
+			local sender = Utils.GetUnitName(unit);
+			if sender then
+				units[#units + 1] = { sender = sender, guid = UnitGUID(unit) };
+			end
+		end
+	end
+
+	local groupPrefix = IsInRaid() and "raid" or "party";
+	for i = 1, GetNumGroupMembers() do
+		local unit = groupPrefix .. i;
+		if UnitExists(unit) and UnitIsPlayer(unit) then
+			local sender = Utils.GetUnitName(unit);
+			if sender then
+				units[#units + 1] = { sender = sender, guid = UnitGUID(unit) };
+			end
+		end
+	end
+
+	return units;
+end
+
+---Resolves an emote's target to a sender by bare-name match, falling back to live units when
+---PlayerCache has no entry (i.e. the target never spoke).
 ---@param message string
 ---@param sourceSender string? Full sender name or Name-Realm
 ---@return string? bareName
@@ -258,19 +304,20 @@ function PlayerCache:ResolveEmoteSender(message, sourceSender)
 			local bareName = sender:match("^([^%-]+)");
 
 			-- Skip the emote's own sender (both bare and full comparison).
-			if bareName and sender ~= sourceSender and bareName ~= sourceBare then
-				local s, e = message:find(bareName, 1, true);
-				if s then
-					local before = message:sub(s - 1, s - 1);
-					local after  = message:sub(e + 1, e + 1);
-
-					-- Ensure full word match.
-					if (before == "" or before:match("[%s%p]"))
-					and (after == "" or after:match("[%s%p]")) then
-						return bareName, sender, data;
-					end
-				end
+			if bareName and sender ~= sourceSender and bareName ~= sourceBare and IsWholeWordMatch(message, bareName) then
+				return bareName, sender, data;
 			end
+		end
+	end
+
+	for _, unitData in ipairs(GetLiveTargetUnits()) do
+		local sender = unitData.sender;
+		local bareName = sender:match("^([^%-]+)");
+
+		if bareName and sender ~= sourceSender and bareName ~= sourceBare and IsWholeWordMatch(message, bareName) then
+			-- Persist so a later reformat (e.g. reopening a dedicated window) hits byTime directly.
+			local resolvedSender, resolvedGuid = self:InsertAndRetrieve(sender, unitData.guid);
+			return bareName, resolvedSender, { sender = resolvedSender, guid = resolvedGuid };
 		end
 	end
 end

--- a/Eavesdropper.lua
+++ b/Eavesdropper.lua
@@ -54,6 +54,7 @@ function ED.Init()
 		-- DB must be ready first
 		ED.Database:Init();
 		ED.Flyway.ApplyPatches();
+		ED.PlayerCache:BackfillFromGroupRoster();
 
 		ED.QuestText.Init();
 		ED.MSP.Init();


### PR DESCRIPTION
When we have emotes and "Format Emote Targets" on, we check the PlayerCache and hope to find whoever it is related to.

Sometimes that's not possible if your cache has evicted (/reload or other means) yet you still had messages pointing to them.

This makes us able to grab the player (and put them in the cache) by live unit (target, mouseover, focus) or by checking if we can find them part of your group/raid (RP events, etc.).

Note: This is not a definitive fix for emote targets formatting breaking. As when we don't have them cached nor have this new path to gather their info.. It'll still show the OOC name.

~~This targeted fix will be in another commit once done.~~
This has now been included.