### PR TITLE
Ignore more blizz emotes that use "you" as self-narration (no notifications necessary)

### DIFF
--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -153,6 +153,15 @@ Constants.CHAT_HISTORY = {
 		"hiss at everyone around you",
 		"are jealous of everyone around you",
 		"pout at everyone around you",
+		"know you'll be right back",
+		"you mourn the death of",
+		"know that you are tired",
+		"know that you are cold",
+		"know that you were just kidding",
+		"know that you are hopelessly lost",
+		"know that you are ready",
+		"know you are thirsty",
+		"that you must be going",
 	},
 };
 


### PR DESCRIPTION
Self-explanatory.

Some of these would only show to the local user and trigger a "blizzard emote at you" notification.