### PR TITLE
Cache PlayerCache identities from visible nameplates

### DIFF
--- a/Core/Events.lua
+++ b/Core/Events.lua
@@ -22,6 +22,7 @@ Events:RegisterEvent("PLAYER_FOCUS_CHANGED");
 Events:RegisterEvent("PLAYER_TARGET_CHANGED");
 Events:RegisterEvent("UPDATE_MOUSEOVER_UNIT");
 Events:RegisterEvent("GROUP_ROSTER_UPDATE");
+Events:RegisterEvent("NAME_PLATE_UNIT_ADDED");
 
 ---Fired when combat begins (regen disabled). Handles frame visibility if HideInCombat is set.
 function Events:PLAYER_REGEN_DISABLED()
@@ -83,6 +84,11 @@ function Events:GUILD_ROSTER_UPDATE()
 			Events:UnregisterEvent("GUILD_ROSTER_UPDATE");
 		end
 	end);
+end
+
+---Fired when a nameplate appears; caches the unit's identity for later resolution.
+function Events:NAME_PLATE_UNIT_ADDED(_, unitToken)
+	ED.PlayerCache:CacheNameplateUnit(unitToken);
 end
 
 ED.Events = Events;

--- a/Core/PlayerCache.lua
+++ b/Core/PlayerCache.lua
@@ -318,6 +318,16 @@ local function GetLiveTargetUnits()
 	return units;
 end
 
+---Resolves and caches a nameplate's player identity as soon as it appears, so they stay
+---resolvable through the normal PlayerCache TTL even after their nameplate disappears again.
+---@param unitToken string
+function PlayerCache:CacheNameplateUnit(unitToken)
+	local sender, guid = ResolveUnitSenderGuid(unitToken, Utils.GetUnitName()); -- No arg: own name, for the fallback check.
+	if sender then
+		self:InsertAndRetrieve(sender, guid);
+	end
+end
+
 ---Finds a live unit whose bare name matches, from a precomputed unit list.
 ---@param units {sender:string, guid:string?}[]
 ---@param bareName string


### PR DESCRIPTION
When someone nearby was targeted by an emote, Eavesdropper could only resolve their identity if they were your target, mouseover, focus, or group member at that exact instant. If they moved out of nameplate range a moment earlier, resolution failed even if they were visible seconds prior.

This update automatically resolves a player's identity as soon as their nameplate appears and adds it to `PlayerCache`. These entries now benefit from the standard hour-long cache window and reload cleanup used across the rest of the addon.

I'll be monitoring if this cache is too heavy for 0.6.0 or later, as we can always revert it or put it in a separate savedvariablers .lua file like TRP does for its directory (if it becomes too big etc).