### PR TITLE
Backfill PlayerCache from guild roster

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -237,6 +237,12 @@ stds.wow = {
 			},
 		},
 
+		C_GuildInfo = {
+			fields = {
+				"GuildRoster",
+			},
+		},
+
 		C_Item = {
 			fields = {
 				"DoesItemExistByID",
@@ -593,6 +599,7 @@ stds.wow = {
 		"GetFileIDFromPath",
 		"GetFrameMetatable",
 		"GetGuildInfo",
+		"GetGuildRosterInfo",
 		"GetInventoryItemTexture",
 		"GetInventorySlotInfo",
 		"GetKeysArray",
@@ -604,6 +611,7 @@ stds.wow = {
 		"GetMouseFocus",
 		"GetNormalizedRealmName",
 		"GetNumGroupMembers",
+		"GetNumGuildMembers",
 		"GetNumLanguages",
 		"GetPlayerInfoByGUID",
 		"GetRealmName",

--- a/Core/Events.lua
+++ b/Core/Events.lua
@@ -22,6 +22,7 @@ Events:RegisterEvent("PLAYER_FOCUS_CHANGED");
 Events:RegisterEvent("PLAYER_TARGET_CHANGED");
 Events:RegisterEvent("UPDATE_MOUSEOVER_UNIT");
 Events:RegisterEvent("GROUP_ROSTER_UPDATE");
+Events:RegisterEvent("GUILD_ROSTER_UPDATE");
 
 ---Fired when combat begins (regen disabled). Handles frame visibility if HideInCombat is set.
 function Events:PLAYER_REGEN_DISABLED()
@@ -65,6 +66,21 @@ end
 ---Fired when group composition changes.
 function Events:GROUP_ROSTER_UPDATE()
 	ED.PlayerCache:BackfillFromGroupRoster();
+end
+
+---Guild/communities panel re-fires this repeatedly while open; debounced so a burst
+---collapses into one backfill pass instead of re-scanning the whole roster each time.
+local guildRosterUpdatePending = false;
+
+---Also fires after our own GuildRoster() request completes, not just on external roster changes.
+function Events:GUILD_ROSTER_UPDATE()
+	if guildRosterUpdatePending then return; end
+	guildRosterUpdatePending = true;
+
+	C_Timer.After(1, function()
+		guildRosterUpdatePending = false;
+		ED.PlayerCache:BackfillFromGuildRoster();
+	end);
 end
 
 ED.Events = Events;

--- a/Core/Events.lua
+++ b/Core/Events.lua
@@ -22,7 +22,6 @@ Events:RegisterEvent("PLAYER_FOCUS_CHANGED");
 Events:RegisterEvent("PLAYER_TARGET_CHANGED");
 Events:RegisterEvent("UPDATE_MOUSEOVER_UNIT");
 Events:RegisterEvent("GROUP_ROSTER_UPDATE");
-Events:RegisterEvent("GUILD_ROSTER_UPDATE");
 
 ---Fired when combat begins (regen disabled). Handles frame visibility if HideInCombat is set.
 function Events:PLAYER_REGEN_DISABLED()
@@ -68,8 +67,9 @@ function Events:GROUP_ROSTER_UPDATE()
 	ED.PlayerCache:BackfillFromGroupRoster();
 end
 
----Guild/communities panel re-fires this repeatedly while open; debounced so a burst
----collapses into one backfill pass instead of re-scanning the whole roster each time.
+---Guild/communities panel re-fires this repeatedly while open, so it's debounced and only
+---registered while a bare name is actually pending (PlayerCache:InsertAndRetrieve resumes it);
+---unregistered below once nothing's left.
 local guildRosterUpdatePending = false;
 
 ---Also fires after our own GuildRoster() request completes, not just on external roster changes.
@@ -79,7 +79,9 @@ function Events:GUILD_ROSTER_UPDATE()
 
 	C_Timer.After(1, function()
 		guildRosterUpdatePending = false;
-		ED.PlayerCache:BackfillFromGuildRoster();
+		if not ED.PlayerCache:BackfillFromGuildRoster() then
+			Events:UnregisterEvent("GUILD_ROSTER_UPDATE");
+		end
 	end);
 end
 

--- a/Core/PlayerCache.lua
+++ b/Core/PlayerCache.lua
@@ -108,7 +108,7 @@ local function RemoveByTimeSlot(time)
 	end
 end
 
----Inserts or updates a sender  <-> GUID mapping across all three indices and persists to CharDB.
+---Inserts or updates a sender <-> GUID mapping across all three indices and persists to CharDB.
 ---@param sender string
 ---@param guid string?
 ---@return string sender Full sender name with realm
@@ -349,6 +349,44 @@ function PlayerCache:BackfillFromGroupRoster()
 	local liveUnits = GetLiveTargetUnits();
 	for _, bareName in ipairs(bareNames) do
 		local sender, guid = FindUnitByName(liveUnits, bareName);
+		if sender then
+			self:InsertAndRetrieve(sender, guid);
+		end
+	end
+end
+
+---GetGuildRosterInfo returns sender and guid directly, without needing a live unit token
+---like GetLiveTargetUnits does.
+---@return {sender:string, guid:string?}[]
+local function GetGuildRosterUnits()
+	local units = {};
+
+	for i = 1, GetNumGuildMembers() do
+		local name, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, guid = GetGuildRosterInfo(i);
+		if name then
+			units[#units + 1] = { sender = name, guid = guid };
+		end
+	end
+
+	return units;
+end
+
+---Upgrades any bare-name bySender entries that match a guild roster member, instead of waiting
+---for their next chat message. Run on login and guild roster changes.
+function PlayerCache:BackfillFromGuildRoster()
+	if not IsInGuild() then return; end
+
+	local bareNames = {};
+	for sender in pairs(self.bySender) do
+		if not Utils.HasRealmSuffix(sender) then
+			bareNames[#bareNames + 1] = sender;
+		end
+	end
+	if #bareNames == 0 then return; end
+
+	local guildUnits = GetGuildRosterUnits();
+	for _, bareName in ipairs(bareNames) do
+		local sender, guid = FindUnitByName(guildUnits, bareName);
 		if sender then
 			self:InsertAndRetrieve(sender, guid);
 		end

--- a/Core/PlayerCache.lua
+++ b/Core/PlayerCache.lua
@@ -177,6 +177,11 @@ function PlayerCache:InsertAndRetrieve(sender, guid)
 	self.byTime[cacheTime] = { sender = sender, guid = guid };
 	tinsert(sortedTimes, 1, cacheTime); -- Newest first.
 
+	-- A bare name just landed in the cache; resume listening for a guild match.
+	if not Utils.HasRealmSuffix(sender) and IsInGuild() then
+		ED.Events:RegisterEvent("GUILD_ROSTER_UPDATE");
+	end
+
 	-- Persist immediately to CharDB.
 	if EavesdropperCharDB then
 		EavesdropperCharDB.playerCache = {
@@ -371,10 +376,20 @@ local function GetGuildRosterUnits()
 	return units;
 end
 
+---Returns true if any bySender entry is still keyed under a bare (no-realm) name.
+---@return boolean
+function PlayerCache:HasBareNames()
+	for sender in pairs(self.bySender) do
+		if not Utils.HasRealmSuffix(sender) then return true; end
+	end
+	return false;
+end
+
 ---Upgrades any bare-name bySender entries that match a guild roster member, instead of waiting
 ---for their next chat message. Run on login and guild roster changes.
+---@return boolean madeProgress False once nothing more can resolve against the current roster.
 function PlayerCache:BackfillFromGuildRoster()
-	if not IsInGuild() then return; end
+	if not IsInGuild() then return false; end
 
 	local bareNames = {};
 	for sender in pairs(self.bySender) do
@@ -382,15 +397,19 @@ function PlayerCache:BackfillFromGuildRoster()
 			bareNames[#bareNames + 1] = sender;
 		end
 	end
-	if #bareNames == 0 then return; end
+	if #bareNames == 0 then return false; end
 
 	local guildUnits = GetGuildRosterUnits();
+	local resolved = 0;
 	for _, bareName in ipairs(bareNames) do
 		local sender, guid = FindUnitByName(guildUnits, bareName);
 		if sender then
 			self:InsertAndRetrieve(sender, guid);
+			resolved = resolved + 1;
 		end
 	end
+
+	return resolved > 0;
 end
 
 ---Resolves an emote's target to a sender by bare-name match, preferring the most recently seen

--- a/Eavesdropper.lua
+++ b/Eavesdropper.lua
@@ -55,7 +55,12 @@ function ED.Init()
 		ED.Database:Init();
 		ED.Flyway.ApplyPatches();
 		ED.PlayerCache:BackfillFromGroupRoster();
-		if IsInGuild() then C_GuildInfo.GuildRoster(); end
+		if IsInGuild() then
+			C_GuildInfo.GuildRoster();
+			if ED.PlayerCache:HasBareNames() then
+				ED.Events:RegisterEvent("GUILD_ROSTER_UPDATE");
+			end
+		end
 
 		ED.QuestText.Init();
 		ED.MSP.Init();

--- a/Eavesdropper.lua
+++ b/Eavesdropper.lua
@@ -55,6 +55,7 @@ function ED.Init()
 		ED.Database:Init();
 		ED.Flyway.ApplyPatches();
 		ED.PlayerCache:BackfillFromGroupRoster();
+		if IsInGuild() then C_GuildInfo.GuildRoster(); end
 
 		ED.QuestText.Init();
 		ED.MSP.Init();


### PR DESCRIPTION
This is mostly an extra. If our player cache only has a bareName of someone and they happen to be in your guild, it will upgrade it to a proper full identity (name-realm and GUID), which lets us properly format their stuff.

~~We debounce the guild event just in case, as during testing I noticed it can get 'loud' (it's not expensive though, so not to worry there).~~

`GUILD_ROSTER_UPDATE` previously remained permanently registered, causing full guild-roster scans on every guild event even when no bare names needed resolving.

The addon now dynamically toggles this listener: the event unregisters itself as soon as a backfill pass makes no further progress (either everything is resolved, or we can't resolve it through the guild member path), and re-registers via `PlayerCache:InsertAndRetrieve` whenever a bare name enters or re-enters the cache (or at login, if bare names already carried over from a previous session).