### PR TITLE
Exempt ROLL events from message deduplication

### DIFF
--- a/Core/ChatHistory.lua
+++ b/Core/ChatHistory.lua
@@ -271,6 +271,9 @@ end
 ---@param guid string? Sender GUID
 ---@return boolean True if duplicate, false otherwise
 function ChatHistory:IsDuplicate(event, sender, message, channel, language, guid)
+	---Rapid identical rolls (fast /roll spam, toys that roll twice) are legitimately repeated, unlike every other event.
+	if event == "ROLL" then return false; end
+
 	local now = GetTime();
 	local window = Constants.CHAT_HISTORY.DUPLICATE_WINDOW;
 


### PR DESCRIPTION
Thanks to @Peterodox for noticing by usage of the [[Worn Troll Dice]](https://www.wowhead.com/item=36862/worn-troll-dice) toy.