### PR TITLE
Leverage `TransformMessages` instead of a full chat redraw

### DIFF
--- a/Core/ChatFormatter.lua
+++ b/Core/ChatFormatter.lua
@@ -473,6 +473,35 @@ function ChatFormatter.FormatTimestamp(entry)
 	return ED.Utils.WrapTextInColor(timestamp, CreateColor(r, g, b)) .. " ", isFrozen;
 end
 
+---Computes entry's name-dependent message body: sender name, message text, and entry colour.
+---Shared by FormatMessage and the targeted rename TransformMessages pass; must not drift apart.
+---@param entry EavesdropperChatEntry
+---@param forGroup boolean? If true, uses group-aware formatting that always embeds the sender name.
+---@param forceDisplayMode number? Overrides the profile NameDisplayMode when set.
+---@param stripMessageHyperlink boolean? If true, remove the hyperlinks in the message but keep the color and []
+---@return string suffix
+---@return string? firstName
+function ChatFormatter.FormatSuffix(entry, forGroup, forceDisplayMode, stripMessageHyperlink)
+	local name, applyRPName, firstName = ChatFormatter.GetFormattedName(entry, forceDisplayMode);
+
+	-- Does nothing for formats that never embed name (e.g. plain SAY).
+	name = ED.Utils.PlayerHyperlink(entry.s, name);
+
+	local eventType = NormalizeEventType(entry.e);
+	local formatTable = forGroup and GROUP_MESSAGE_FORMATS or MESSAGE_FORMATS;
+	local msgText = formatTable[eventType](entry, name, forGroup, stripMessageHyperlink);
+
+	local entryR, entryG, entryB = GetEntryColor(entry);
+	local entryColor = CreateColor(entryR, entryG, entryB);
+	msgText = ED.Utils.WrapTextInColor(msgText, entryColor);
+
+	if entry.e == "CHAT_MSG_TEXT_EMOTE" and applyRPName then
+		msgText = FormatTextEmoteTargetWithRPName(entry, msgText, forceDisplayMode);
+	end
+
+	return msgText, firstName;
+end
+
 ---Formats a full chat entry for display: timestamp, sender name, message body, and entry colour.
 ---@param entry EavesdropperChatEntry
 ---@param forGroup boolean? If true, uses group-aware formatting that always embeds the sender name.
@@ -481,7 +510,7 @@ end
 ---@param stripMessageHyperlink boolean? If true, remove the hyperlinks in the message but keep the color and []
 ---@return string formattedMsg
 ---@return string? firstName
----@return string prefix Everything before the timestamp (the Jump to Context link, or ""); reused as-is by RefreshTimestamps.
+---@return string prefix Everything before the timestamp (the Jump to Context link, or ""); reused as-is by every TransformMessages-based refresh.
 ---@return string suffix Everything after the timestamp; reused as-is by RefreshTimestamps.
 ---@return boolean isFrozen
 function ChatFormatter.FormatMessage(entry, forGroup, forceDisplayMode, showJumpLink, stripMessageHyperlink)
@@ -495,25 +524,7 @@ function ChatFormatter.FormatMessage(entry, forGroup, forceDisplayMode, showJump
 		jumpLink = ED.Utils.JumpHyperlink(entry.id, entry.s, ED.Constants.JUMP_TO_CONTEXT_ICON_INLINE) .. " ";
 	end
 
-	-- Name handling
-	local name, applyRPName, firstName = ChatFormatter.GetFormattedName(entry, forceDisplayMode);
-
-	-- Does nothing for formats that never embed name (e.g. plain SAY).
-	name = ED.Utils.PlayerHyperlink(entry.s, name);
-
-	-- Format message
-	local eventType = NormalizeEventType(entry.e);
-	local formatTable = forGroup and GROUP_MESSAGE_FORMATS or MESSAGE_FORMATS;
-	local msgText = formatTable[eventType](entry, name, forGroup, stripMessageHyperlink);
-
-	-- Apply entry color
-	local entryR, entryG, entryB = GetEntryColor(entry);
-	local entryColor = CreateColor(entryR, entryG, entryB);
-	msgText = ED.Utils.WrapTextInColor(msgText, entryColor);
-
-	if entry.e == "CHAT_MSG_TEXT_EMOTE" and applyRPName then
-		msgText = FormatTextEmoteTargetWithRPName(entry, msgText, forceDisplayMode);
-	end
+	local msgText, firstName = ChatFormatter.FormatSuffix(entry, forGroup, forceDisplayMode, stripMessageHyperlink);
 
 	return jumpLink .. timestamp .. msgText, firstName, jumpLink, msgText, isFrozen;
 end

--- a/Core/ChatFormatter.lua
+++ b/Core/ChatFormatter.lua
@@ -511,7 +511,7 @@ end
 ---@return string formattedMsg
 ---@return string? firstName
 ---@return string prefix Everything before the timestamp (the Jump to Context link, or ""); reused as-is by every TransformMessages-based refresh.
----@return string suffix Everything after the timestamp; reused as-is by RefreshTimestamps.
+---@return string suffix Everything after the timestamp; reused as-is by RefreshTimestamps, rebuilt by RefreshEntriesForIdentity when a player's data changes.
 ---@return boolean isFrozen
 function ChatFormatter.FormatMessage(entry, forGroup, forceDisplayMode, showJumpLink, stripMessageHyperlink)
 	if not entry or not entry.m then return ""; end

--- a/Core/ChatFormatter.lua
+++ b/Core/ChatFormatter.lua
@@ -437,23 +437,18 @@ function ChatFormatter.GetFormattedName(entry, forceDisplayMode)
 	return trimmedName, applyRPName, trimmedFirstName;
 end
 
----Formats a full chat entry for display: timestamp, sender name, message body, and entry colour.
+---Computes entry's aging timestamp label, colour, and whether it has reached TIMESTAMP_FREEZE_AGE.
+---Shared by FormatMessage and Eavesdropper_SharedFrameMixin:RefreshTimestamps; must not drift apart.
 ---@param entry EavesdropperChatEntry
----@param forGroup boolean? If true, uses group-aware formatting that always embeds the sender name.
----@param forceDisplayMode number? Overrides the profile NameDisplayMode when set.
----@param showJumpLink boolean? If true (and forGroup), prepends a Jump to Context link before the timestamp.
----@param stripMessageHyperlink boolean? If true, remove the hyperlinks in the message but keep the color and []
----@return string formattedMsg
----@return string? firstName
-function ChatFormatter.FormatMessage(entry, forGroup, forceDisplayMode, showJumpLink, stripMessageHyperlink)
-	if not entry or not entry.m then return ""; end
-
-	-- Timestamp
+---@return string timestamp
+---@return boolean isFrozen
+function ChatFormatter.FormatTimestamp(entry)
 	local now = time();
 	local age = now - (entry.t or now);
-	local timestamp;
+	local isFrozen = age >= ED.Constants.TIMESTAMP_FREEZE_AGE;
 
-	if age < ED.Constants.TIMESTAMP_FREEZE_AGE then
+	local timestamp;
+	if not isFrozen then
 		timestamp = age < 60 and "<1m" or string.format("%sm", math.floor(age / 60));
 	else
 		timestamp = date("%H:%M", entry.t);
@@ -474,9 +469,25 @@ function ChatFormatter.FormatMessage(entry, forGroup, forceDisplayMode, showJump
 	else
 		r, g, b = 0.02, 0.67, 0.97; -- 0x05ACF8
 	end
-	local timestampColor = CreateColor(r, g, b);
 
-	timestamp = ED.Utils.WrapTextInColor(timestamp, timestampColor) .. " ";
+	return ED.Utils.WrapTextInColor(timestamp, CreateColor(r, g, b)) .. " ", isFrozen;
+end
+
+---Formats a full chat entry for display: timestamp, sender name, message body, and entry colour.
+---@param entry EavesdropperChatEntry
+---@param forGroup boolean? If true, uses group-aware formatting that always embeds the sender name.
+---@param forceDisplayMode number? Overrides the profile NameDisplayMode when set.
+---@param showJumpLink boolean? If true (and forGroup), prepends a Jump to Context link before the timestamp.
+---@param stripMessageHyperlink boolean? If true, remove the hyperlinks in the message but keep the color and []
+---@return string formattedMsg
+---@return string? firstName
+---@return string prefix Everything before the timestamp (the Jump to Context link, or ""); reused as-is by RefreshTimestamps.
+---@return string suffix Everything after the timestamp; reused as-is by RefreshTimestamps.
+---@return boolean isFrozen
+function ChatFormatter.FormatMessage(entry, forGroup, forceDisplayMode, showJumpLink, stripMessageHyperlink)
+	if not entry or not entry.m then return ""; end
+
+	local timestamp, isFrozen = ChatFormatter.FormatTimestamp(entry);
 
 	-- Jump to Context: prepended before the timestamp so its horizontal position never shifts.
 	local jumpLink = "";
@@ -504,7 +515,7 @@ function ChatFormatter.FormatMessage(entry, forGroup, forceDisplayMode, showJump
 		msgText = FormatTextEmoteTargetWithRPName(entry, msgText, forceDisplayMode);
 	end
 
-	return jumpLink .. timestamp .. msgText, firstName;
+	return jumpLink .. timestamp .. msgText, firstName, jumpLink, msgText, isFrozen;
 end
 
 ED.ChatFormatter = ChatFormatter;

--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -44,6 +44,7 @@ Constants.CHANNELS_TO_SKIP_NOTIFICATIONS = {
 ---@field MIN_MENTIONS_HISTORY number
 ---@field MAX_MENTIONS_HISTORY number
 ---@field JUMP_CONTEXT_PADDING number Older messages fetched beyond a Jump to Context target, so there's context above it.
+---@field TICKER_STAGGER_THRESHOLD number Lines when window's timestamp ticker starts using the full stagger spread vs small one.
 Constants.CHAT_BOX = {
 	MIN_FONT_SIZE = 6,
 	MAX_FONT_SIZE = 24,
@@ -55,6 +56,7 @@ Constants.CHAT_BOX = {
 	MIN_MENTIONS_HISTORY = 10,
 	MAX_MENTIONS_HISTORY = 1000,
 	JUMP_CONTEXT_PADDING = 20,
+	TICKER_STAGGER_THRESHOLD = 500,
 };
 
 ---All chat events the addon registers filters for.
@@ -172,8 +174,13 @@ Constants.CHAT_NEW_INDICATOR_FADE_OUT = 10;
 ---@type number
 Constants.WINDOW_REFRESH_INTERVAL = 60;
 
+---Max random offset for a ticker under TICKER_STAGGER_THRESHOLD lines; Windows colliding
+---ticker-wise with another below this threshold don't require WINDOW_REFRESH_INTERVAL to be applied.
+---@type number
+Constants.TICKER_SMALL_STAGGER = 2;
+
 ---Age in seconds at which a message stops changing appearance entirely.
----Shared by ChatFormatter.FormatMessage and the refresh ticker; they must not drift apart.
+---Shared by ChatFormatter.FormatTimestamp and the refresh ticker; they must not drift apart.
 ---@type number
 Constants.TIMESTAMP_FREEZE_AGE = 30 * 60;
 

--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -44,7 +44,7 @@ Constants.CHANNELS_TO_SKIP_NOTIFICATIONS = {
 ---@field MIN_MENTIONS_HISTORY number
 ---@field MAX_MENTIONS_HISTORY number
 ---@field JUMP_CONTEXT_PADDING number Older messages fetched beyond a Jump to Context target, so there's context above it.
----@field TICKER_STAGGER_THRESHOLD number Lines when window's timestamp ticker starts using the full stagger spread vs small one.
+---@field TICKER_STAGGER_THRESHOLD number Line count at which a window's ticker switches from the short stagger to the full spread.
 Constants.CHAT_BOX = {
 	MIN_FONT_SIZE = 6,
 	MAX_FONT_SIZE = 24,
@@ -174,8 +174,8 @@ Constants.CHAT_NEW_INDICATOR_FADE_OUT = 10;
 ---@type number
 Constants.WINDOW_REFRESH_INTERVAL = 60;
 
----Max random offset for a ticker under TICKER_STAGGER_THRESHOLD lines; Windows colliding
----ticker-wise with another below this threshold don't require WINDOW_REFRESH_INTERVAL to be applied.
+---Max random offset for a ticker under TICKER_STAGGER_THRESHOLD lines; below that size, two
+---windows ticking together cost so little that spreading them across WINDOW_REFRESH_INTERVAL isn't worth it.
 ---@type number
 Constants.TICKER_SMALL_STAGGER = 2;
 

--- a/Core/MSPHandler.lua
+++ b/Core/MSPHandler.lua
@@ -46,7 +46,7 @@ function MSP.InvalidatePlayer(playerName)
 
 	MSP.cache[guid] = nil;
 	cacheNames[key] = nil;
-	Eavesdropper_SharedFrameMixin.ScheduleDataRefresh();
+	Eavesdropper_SharedFrameMixin.ScheduleDataRefresh(key, guid);
 end
 
 ---True once TRP3 has fired WORKFLOW_ON_LOADED. TRP3_API existing does not mean it is ready.

--- a/UI/EavesdropperDedicatedFrame.lua
+++ b/UI/EavesdropperDedicatedFrame.lua
@@ -285,8 +285,8 @@ function Eavesdropper_Dedicated_FrameMixin:AddMessage(entry, fromHistory)
 	end
 
 	local r, g, b = ED.ChatFormatter.GetEntryColor(entry);
-	local formatted = ED.ChatFormatter.FormatMessage(entry, false, self.nameDisplayMode, nil, self.stripMessageHyperlink);
-	self.ChatBox:AddMessage(formatted, r, g, b);
+	local formatted, _, prefix, suffix, isFrozen = ED.ChatFormatter.FormatMessage(entry, false, self.nameDisplayMode, nil, self.stripMessageHyperlink);
+	self.ChatBox:AddMessage(formatted, r, g, b, entry, prefix, suffix, isFrozen);
 
 	-- Only track lines (to keep frame awake) when they are actually inserted.
 	self:TrackNewestEntry(entry);

--- a/UI/EavesdropperFrame.lua
+++ b/UI/EavesdropperFrame.lua
@@ -246,7 +246,8 @@ function Eavesdropper_FrameMixin:UpdateTarget()
 		self.eavesdropped_player_guid = nil;
 	end
 
-	-- A new target starts at the bottom; otherwise hold the scroll and skip windows that cannot change.
+	-- New target starts at bottom and requires a real rebuild.
+	-- Same target just needs its timestamp updated for age.
 	if hardUpdate then
 		-- A new target invalidates any new-message indicator lit for the previous one.
 		if self.newIndicatorTimer then
@@ -257,7 +258,7 @@ function Eavesdropper_FrameMixin:UpdateTarget()
 
 		self:RefreshChat();
 	elseif not self:IsTimestampFrozen() then
-		self:RefreshChat(true);
+		self:RefreshTimestamps();
 	end
 
 	self.lastUpdate = now;
@@ -314,8 +315,8 @@ function Eavesdropper_FrameMixin:AddMessage(entry, fromHistory)
 	end
 
 	local r, g, b = ED.ChatFormatter.GetEntryColor(entry);
-	local formatted = ED.ChatFormatter.FormatMessage(entry, nil, nil, nil, self.stripMessageHyperlink);
-	self.ChatBox:AddMessage(formatted, r, g, b);
+	local formatted, _, prefix, suffix, isFrozen = ED.ChatFormatter.FormatMessage(entry, nil, nil, nil, self.stripMessageHyperlink);
+	self.ChatBox:AddMessage(formatted, r, g, b, entry, prefix, suffix, isFrozen);
 
 	-- Only track lines (to keep frame awake) when they are actually inserted.
 	self:TrackNewestEntry(entry);

--- a/UI/EavesdropperFrame.lua
+++ b/UI/EavesdropperFrame.lua
@@ -246,8 +246,7 @@ function Eavesdropper_FrameMixin:UpdateTarget()
 		self.eavesdropped_player_guid = nil;
 	end
 
-	-- New target starts at bottom and requires a real rebuild.
-	-- Same target just needs its timestamp updated for age.
+	-- A new target needs a full rebuild; the same target just needs its timestamp aged.
 	if hardUpdate then
 		-- A new target invalidates any new-message indicator lit for the previous one.
 		if self.newIndicatorTimer then

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -133,6 +133,58 @@ function Eavesdropper_SharedFrameMixin:IsTimestampFrozen()
 	return (time() - self.newestEntryTime) >= Constants.TIMESTAMP_FREEZE_AGE;
 end
 
+---TransformMessages predicate: entries stop being touched once wasFrozen, since a frozen
+---label can never change again (30m+). Data given by AddMessage and kept current by RebuildTimestampMessage.
+---@param message string
+---@param r number
+---@param g number
+---@param b number
+---@param entry EavesdropperChatEntry?
+---@param prefix string?
+---@param suffix string?
+---@param wasFrozen boolean?
+---@return boolean
+local function IsTimestampNotYetFrozen(message, r, g, b, entry, prefix, suffix, wasFrozen) -- luacheck: no unused (message, r, g, b, prefix, suffix)
+	return entry ~= nil and not wasFrozen;
+end
+
+---TransformMessages transform: rebuilds only the timestamp portion, reusing prefix/suffix untouched.
+---@param message string
+---@param r number
+---@param g number
+---@param b number
+---@param entry EavesdropperChatEntry
+---@param prefix string
+---@param suffix string
+---@return string message
+---@return number r
+---@return number g
+---@return number b
+---@return EavesdropperChatEntry entry
+---@return string prefix
+---@return string suffix
+---@return boolean isFrozen
+local function RebuildTimestampMessage(message, r, g, b, entry, prefix, suffix, wasFrozen) -- luacheck: no unused (message, wasFrozen)
+	local timestamp, isFrozen = ED.ChatFormatter.FormatTimestamp(entry);
+	return prefix .. timestamp .. suffix, r, g, b, entry, prefix, suffix, isFrozen;
+end
+
+---Ages every non-frozen (< TIMESTAMP_FREEZE_AGE) line's timestamp in place with TransformMessages.
+---This is performance-wise way better than re-drawing the entire window as we did prior.
+function Eavesdropper_SharedFrameMixin:RefreshTimestamps()
+	if not self.ChatBox then return; end
+	self.ChatBox:TransformMessages(IsTimestampNotYetFrozen, RebuildTimestampMessage);
+end
+
+---Wide stagger is required when a window has enough lines that colliding with another window's
+---ticker would actually become problematic cost-wise. < TICKER_STAGGER_THRESHOLD is small stagger.
+---@param frame table
+---@return boolean
+local function NeedsWideStagger(frame)
+	local numMessages = frame.ChatBox and frame.ChatBox:GetNumMessages() or 0;
+	return numMessages >= Constants.CHAT_BOX.TICKER_STAGGER_THRESHOLD;
+end
+
 ---Start the periodic refresh that ages the timestamps on this window.
 ---The first tick is offset randomly, so windows shown together do not refresh in the same frame.
 ---Stops itself once every line is frozen; TryAddMessage starts it again.
@@ -142,15 +194,27 @@ function Eavesdropper_SharedFrameMixin:StartChatTicker()
 	if self.chatTicker or self.chatTickerDelay then return; end
 
 	local interval = Constants.WINDOW_REFRESH_INTERVAL;
+	local needsWideStagger = NeedsWideStagger(self);
+	local offsetRange = needsWideStagger and interval or Constants.TICKER_SMALL_STAGGER;
 
-	self.chatTickerDelay = C_Timer.NewTimer(math.random() * interval, function()
+	self.chatTickerNeedsWideStagger = needsWideStagger;
+
+	self.chatTickerDelay = C_Timer.NewTimer(math.random() * offsetRange, function()
 		self.chatTickerDelay = nil;
 		self.chatTicker = C_Timer.NewTicker(interval, function()
 			-- Refresh before testing; the tick that freezes a window still has a label to draw.
-			self:RefreshChat(true);
+			self:RefreshTimestamps();
 
 			if self:IsTimestampFrozen() then
 				self:StopChatTicker();
+				return;
+			end
+
+			-- The offset picked at start never updates on its own; restart with a fresh one if
+			-- this window has grown across the stagger threshold since then.
+			if NeedsWideStagger(self) ~= self.chatTickerNeedsWideStagger then
+				self:StopChatTicker();
+				self:StartChatTicker();
 			end
 		end);
 	end);

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -156,9 +156,8 @@ local function ShouldRefreshTimestamp(message, r, g, b, entry, prefix, suffix, w
 	return entry.e == "CHAT_MSG_TEXT_EMOTE" and not entry.tg;
 end
 
----Ages every non-frozen (< TIMESTAMP_FREEZE_AGE) line's timestamp in place with TransformMessages.
----Also retries resolving an unresolved emote target, which otherwise only got a chance during a full rebuild.
----This is performance-wise way better than re-drawing the entire window as we did prior.
+---Updates timestamps in place via TransformMessages instead of clearing and rebuilding the window.
+---Also retries an unresolved emote target, which otherwise only got fixed during a full rebuild.
 function Eavesdropper_SharedFrameMixin:RefreshTimestamps()
 	if not self.ChatBox then return; end
 
@@ -178,8 +177,8 @@ function Eavesdropper_SharedFrameMixin:RefreshTimestamps()
 	self.ChatBox:TransformMessages(ShouldRefreshTimestamp, RebuildTimestampMessage);
 end
 
----Prefers GUID equality when both sides have one; entry.g can be nil (see EavesdropperChatEntry).
----We use name as the fallback, not as a second independent check.
+---Prefers GUID equality when both sides have one; entry.g can be nil (see EavesdropperChatEntry),
+---so name is the fallback here, not a second check run alongside it.
 ---@param entryGuid string?
 ---@param entryName string?
 ---@param guid string?
@@ -217,8 +216,8 @@ function Eavesdropper_SharedFrameMixin:RefreshEntriesForIdentity(name, guid, for
 	self.ChatBox:TransformMessages(MatchesIdentity, RebuildSuffixMessage);
 end
 
----Wide stagger is required when a window has enough lines that colliding with another window's
----ticker would actually become problematic cost-wise. < TICKER_STAGGER_THRESHOLD is small stagger.
+---True once a window is big enough that two ticks landing on the same frame would actually be
+---felt; smaller windows use the short stagger instead.
 ---@param frame table
 ---@return boolean
 local function NeedsWideStagger(frame)
@@ -312,8 +311,8 @@ end
 ---True while the burst window's cooldown is running.
 local dataRefreshOnCooldown = false;
 
----True when a blanket ("changed, unknown who") invalidation arrives during the cooldown.
----This takes priority over dataRefreshPendingIdentities when the cooldown expires.
+---True once a blanket ("changed, unknown who") invalidation arrives during the cooldown;
+---wins out over dataRefreshPendingIdentities once the cooldown expires.
 local dataRefreshPendingBlanket = false;
 
 ---Targeted redraws collected during the cooldown, using Name-Realm so one player showing up
@@ -341,7 +340,6 @@ function Eavesdropper_SharedFrameMixin.RefreshAllWindows()
 end
 
 ---Targeted counterpart to RefreshAllWindows, for when only one player's data changed.
----This is way better for performance and should be preferred when we have enough data.
 ---@param name string Changed player's Name-Realm.
 ---@param guid string? Their GUID, when known.
 function Eavesdropper_SharedFrameMixin.RefreshEntriesForPlayer(name, guid)

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -133,8 +133,14 @@ function Eavesdropper_SharedFrameMixin:IsTimestampFrozen()
 	return (time() - self.newestEntryTime) >= Constants.TIMESTAMP_FREEZE_AGE;
 end
 
----TransformMessages predicate: entries stop being touched once wasFrozen, since a frozen
----label can never change again (30m+). Data given by AddMessage and kept current by RebuildTimestampMessage.
+---Default override point; Main has no per-window display mode so this returns nil (profile default).
+---@return number?
+function Eavesdropper_SharedFrameMixin:GetNameDisplayMode()
+	return nil;
+end
+
+---TransformMessages predicate: touches an entry while its timestamp hasn't frozen, or it's a
+---text emote whose target is still unresolved (see RefreshTimestamps' transform for the retry).
 ---@param message string
 ---@param r number
 ---@param g number
@@ -144,36 +150,32 @@ end
 ---@param suffix string?
 ---@param wasFrozen boolean?
 ---@return boolean
-local function IsTimestampNotYetFrozen(message, r, g, b, entry, prefix, suffix, wasFrozen) -- luacheck: no unused (message, r, g, b, prefix, suffix)
-	return entry ~= nil and not wasFrozen;
-end
-
----TransformMessages transform: rebuilds only the timestamp portion, reusing prefix/suffix untouched.
----@param message string
----@param r number
----@param g number
----@param b number
----@param entry EavesdropperChatEntry
----@param prefix string
----@param suffix string
----@return string message
----@return number r
----@return number g
----@return number b
----@return EavesdropperChatEntry entry
----@return string prefix
----@return string suffix
----@return boolean isFrozen
-local function RebuildTimestampMessage(message, r, g, b, entry, prefix, suffix, wasFrozen) -- luacheck: no unused (message, wasFrozen)
-	local timestamp, isFrozen = ED.ChatFormatter.FormatTimestamp(entry);
-	return prefix .. timestamp .. suffix, r, g, b, entry, prefix, suffix, isFrozen;
+local function ShouldRefreshTimestamp(message, r, g, b, entry, prefix, suffix, wasFrozen) -- luacheck: no unused (message, r, g, b, prefix, suffix)
+	if not entry then return false; end
+	if not wasFrozen then return true; end
+	return entry.e == "CHAT_MSG_TEXT_EMOTE" and not entry.tg;
 end
 
 ---Ages every non-frozen (< TIMESTAMP_FREEZE_AGE) line's timestamp in place with TransformMessages.
+---Also retries resolving an unresolved emote target, which otherwise only got a chance during a full rebuild.
 ---This is performance-wise way better than re-drawing the entire window as we did prior.
 function Eavesdropper_SharedFrameMixin:RefreshTimestamps()
 	if not self.ChatBox then return; end
-	self.ChatBox:TransformMessages(IsTimestampNotYetFrozen, RebuildTimestampMessage);
+
+	-- forceDisplayMode is per-window; closed over here since the transform can't read self.
+	local forceDisplayMode = self:GetNameDisplayMode();
+
+	local function RebuildTimestampMessage(message, r, g, b, entry, prefix, suffix, wasFrozen) -- luacheck: no unused (message, wasFrozen)
+		local timestamp, isFrozen = ED.ChatFormatter.FormatTimestamp(entry);
+
+		if entry.e == "CHAT_MSG_TEXT_EMOTE" and not entry.tg then
+			suffix = ED.ChatFormatter.FormatTextEmoteTargetWithRPName(entry, suffix, forceDisplayMode);
+		end
+
+		return prefix .. timestamp .. suffix, r, g, b, entry, prefix, suffix, isFrozen;
+	end
+
+	self.ChatBox:TransformMessages(ShouldRefreshTimestamp, RebuildTimestampMessage);
 end
 
 ---Wide stagger is required when a window has enough lines that colliding with another window's

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -178,6 +178,45 @@ function Eavesdropper_SharedFrameMixin:RefreshTimestamps()
 	self.ChatBox:TransformMessages(ShouldRefreshTimestamp, RebuildTimestampMessage);
 end
 
+---Prefers GUID equality when both sides have one; entry.g can be nil (see EavesdropperChatEntry).
+---We use name as the fallback, not as a second independent check.
+---@param entryGuid string?
+---@param entryName string?
+---@param guid string?
+---@param name string
+---@return boolean
+local function IdentityMatches(entryGuid, entryName, guid, name)
+	if guid and entryGuid then
+		return entryGuid == guid;
+	end
+	return entryName == name;
+end
+
+---Rebuilds only the entries belonging to, or targeting (see FormatTextEmoteTargetWithRPName),
+---one player via TransformMessages, for when only that player's profile data changed.
+---@param name string Changed player's Name-Realm.
+---@param guid string? Their GUID, when known.
+---@param forGroup boolean? Passed straight through to FormatSuffix.
+function Eavesdropper_SharedFrameMixin:RefreshEntriesForIdentity(name, guid, forGroup)
+	if not self.ChatBox then return; end
+
+	local forceDisplayMode = self:GetNameDisplayMode();
+	local stripMessageHyperlink = self.stripMessageHyperlink;
+
+	local function MatchesIdentity(message, r, g, b, entry, prefix, suffix, wasFrozen) -- luacheck: no unused (message, r, g, b, prefix, suffix, wasFrozen)
+		if not entry then return false; end
+		return IdentityMatches(entry.g, entry.s, guid, name) or IdentityMatches(entry.tg, entry.tn, guid, name);
+	end
+
+	local function RebuildSuffixMessage(message, r, g, b, entry, prefix, suffix, wasFrozen) -- luacheck: no unused (message, wasFrozen)
+		local timestamp, isFrozen = ED.ChatFormatter.FormatTimestamp(entry);
+		local newSuffix = ED.ChatFormatter.FormatSuffix(entry, forGroup, forceDisplayMode, stripMessageHyperlink);
+		return prefix .. timestamp .. newSuffix, r, g, b, entry, prefix, newSuffix, isFrozen;
+	end
+
+	self.ChatBox:TransformMessages(MatchesIdentity, RebuildSuffixMessage);
+end
+
 ---Wide stagger is required when a window has enough lines that colliding with another window's
 ---ticker would actually become problematic cost-wise. < TICKER_STAGGER_THRESHOLD is small stagger.
 ---@param frame table
@@ -273,8 +312,14 @@ end
 ---True while the burst window's cooldown is running.
 local dataRefreshOnCooldown = false;
 
----True if an invalidation arrived during the cooldown and still needs a redraw.
-local dataRefreshPending = false;
+---True when a blanket ("changed, unknown who") invalidation arrives during the cooldown.
+---This takes priority over dataRefreshPendingIdentities when the cooldown expires.
+local dataRefreshPendingBlanket = false;
+
+---Targeted redraws collected during the cooldown, using Name-Realm so one player showing up
+---twice in a burst only redraws once; value is their GUID (which may be nil).
+---@type table<string, string?>
+local dataRefreshPendingIdentities = {};
 
 ---Dedicated and Group windows only exist in the registry while shown, so they always redraw;
 ---Main and Mentions are checked for IsShown() first.
@@ -295,6 +340,24 @@ function Eavesdropper_SharedFrameMixin.RefreshAllWindows()
 	end);
 end
 
+---Targeted counterpart to RefreshAllWindows, for when only one player's data changed.
+---This is way better for performance and should be preferred when we have enough data.
+---@param name string Changed player's Name-Realm.
+---@param guid string? Their GUID, when known.
+function Eavesdropper_SharedFrameMixin.RefreshEntriesForPlayer(name, guid)
+	Eavesdropper_SharedFrameMixin.ForEachManagedFrame(function(frame, family)
+		if family == "main" or family == "mentions" then
+			if not frame:IsShown() then return; end
+		end
+
+		if family == "group" then
+			frame.playerListDirty = true;
+		end
+
+		frame:RefreshEntriesForIdentity(name, guid, family == "group" or family == "mentions");
+	end);
+end
+
 ---Main is skipped: its OnHide never reads isCombatHidden, unlike Dedicated/Group/Mentions.
 ---@param combatHidden boolean
 function Eavesdropper_SharedFrameMixin.ApplyCombatHidden(combatHidden)
@@ -310,30 +373,51 @@ end
 ---idle. Keeps a sustained burst on a steady interval instead of having it basically spam.
 local function ArmDataRefreshCooldown()
 	C_Timer.NewTimer(Constants.DATA_REFRESH_THROTTLE, function()
-		if not dataRefreshPending then
+		if not dataRefreshPendingBlanket and not next(dataRefreshPendingIdentities) then
 			dataRefreshOnCooldown = false;
 			ED.Debug:Print("ScheduleDataRefresh: cooldown expired, idle");
 			return;
 		end
 
-		dataRefreshPending = false;
-		ED.Debug:Print("ScheduleDataRefresh: cooldown expired, trailing redraw");
-		Eavesdropper_SharedFrameMixin.RefreshAllWindows();
+		if dataRefreshPendingBlanket then
+			dataRefreshPendingBlanket = false;
+			wipe(dataRefreshPendingIdentities);
+			ED.Debug:Print("ScheduleDataRefresh: cooldown expired, blanket redraw");
+			Eavesdropper_SharedFrameMixin.RefreshAllWindows();
+		else
+			ED.Debug:Print("ScheduleDataRefresh: cooldown expired, targeted redraw");
+			for name, guid in pairs(dataRefreshPendingIdentities) do
+				Eavesdropper_SharedFrameMixin.RefreshEntriesForPlayer(name, guid);
+			end
+			wipe(dataRefreshPendingIdentities);
+		end
+
 		ArmDataRefreshCooldown();
 	end);
 end
 
 ---Entry point for MSP invalidation to request a redraw. Invalidation sources must always
----come through here, never call RefreshChat directly.
-function Eavesdropper_SharedFrameMixin.ScheduleDataRefresh()
+---come through here, never call RefreshChat/RefreshEntriesForIdentity directly.
+---@param name string? Changed player's Name-Realm; omit for a blanket "changed, unknown who" redraw.
+---@param guid string? Their GUID, when known.
+function Eavesdropper_SharedFrameMixin.ScheduleDataRefresh(name, guid)
 	if dataRefreshOnCooldown then
-		dataRefreshPending = true;
+		if name and not dataRefreshPendingBlanket then
+			dataRefreshPendingIdentities[name] = guid;
+		else
+			dataRefreshPendingBlanket = true;
+		end
 		ED.Debug:Print("ScheduleDataRefresh: on cooldown, queued");
 		return;
 	end
 
-	ED.Debug:Print("ScheduleDataRefresh: leading edge, redrawing now");
-	Eavesdropper_SharedFrameMixin.RefreshAllWindows();
+	if name then
+		ED.Debug:Print("ScheduleDataRefresh: immediate targeted redraw");
+		Eavesdropper_SharedFrameMixin.RefreshEntriesForPlayer(name, guid);
+	else
+		ED.Debug:Print("ScheduleDataRefresh: immediate blanket redraw");
+		Eavesdropper_SharedFrameMixin.RefreshAllWindows();
+	end
 
 	dataRefreshOnCooldown = true;
 	ArmDataRefreshCooldown();

--- a/UI/EavesdropperGroupFrame.lua
+++ b/UI/EavesdropperGroupFrame.lua
@@ -413,8 +413,8 @@ function Eavesdropper_Group_FrameMixin:AddMessage(entry, fromHistory)
 
 	local r, g, b = ED.ChatFormatter.GetEntryColor(entry);
 	local showJumpLink = ED.Database:GetGlobalSetting("DedicatedWindows") and ED.Database:GetGlobalSetting("GroupWindowsJumpToContext");
-	local formatted = ED.ChatFormatter.FormatMessage(entry, true, self.nameDisplayMode, showJumpLink, self.stripMessageHyperlink);
-	self.ChatBox:AddMessage(formatted, r, g, b);
+	local formatted, _, prefix, suffix, isFrozen = ED.ChatFormatter.FormatMessage(entry, true, self.nameDisplayMode, showJumpLink, self.stripMessageHyperlink);
+	self.ChatBox:AddMessage(formatted, r, g, b, entry, prefix, suffix, isFrozen);
 
 	-- Only track lines (to keep frame awake) when they are actually inserted.
 	self:TrackNewestEntry(entry);

--- a/UI/EavesdropperMentionsFrame.lua
+++ b/UI/EavesdropperMentionsFrame.lua
@@ -264,8 +264,8 @@ function Eavesdropper_Mentions_FrameMixin:AddMessage(entry, fromHistory)
 
 	local r, g, b = ED.ChatFormatter.GetEntryColor(entry);
 	local showJumpLink = ED.Database:GetGlobalSetting("DedicatedWindows") and ED.Database:GetGlobalSetting("MentionsHistoryJumpToContext");
-	local formatted = ED.ChatFormatter.FormatMessage(entry, true, self:GetNameDisplayMode(), showJumpLink, self.stripMessageHyperlink);
-	self.ChatBox:AddMessage(formatted, r, g, b);
+	local formatted, _, prefix, suffix, isFrozen = ED.ChatFormatter.FormatMessage(entry, true, self:GetNameDisplayMode(), showJumpLink, self.stripMessageHyperlink);
+	self.ChatBox:AddMessage(formatted, r, g, b, entry, prefix, suffix, isFrozen);
 
 	if not fromHistory then
 		self:RefreshEmptyState();


### PR DESCRIPTION
Three chat-window operations used to nuke the entire window and rebuild it from scratch every time, even when almost nothing in the window actually.. required this.

1. Timestamp aging: Every 60s a plain ticker would age timestamps ("<1m" becomes "1m" etc.), which used to do a full `Clear()` and then reformat every tick, for every window.
2. Emote targets: When someone uses `/wave` at John, and John isn't resolved yet to `John Stormwind`, we used to only get a retry when something else happened that would trigger a 'full' rebuild.
3. Profile renames: MSP/TRP data changing for one person used to redraw every open window in full, even if that window was a group window of 300 lines with only like 8 lines written by that person.

All three above are now fixed by tackling it in the same way: `TransformMessages`.
This basically patches just the lines that actually need to change instead of clearing and reformatting everything.
(An example of this on Blizzard's end is here: https://github.com/Gethe/wow-ui-source/blob/31c7f7b9cc79e56c986b365c06a6afbcf3c9177b/Interface/AddOns/Blizzard_ChatFrameBase/Shared/ChatFrameUtil.lua#L786-L811)

The 60s 'timestamp' ticker now only touches lines whose timestamp label would actually change. It also now retries retries unresolved emote targets quietly to resolve those just in case there's new data available.

For renames (MSP/TRP) it finds just that person's lines (by GUID, or by name if we don't have that yet) and only touches those.
The existing 5-second burst throttle is unchanged, so if several people change at once, it still fires one redraw per person rather than one combined pass. However these all use the TransformMessages route now instead of doing a full redraw for each. It's (probably) still a win, but I did not stress-test this specifically.

If I did this correctly (fingers crossed), the end-user should see nothing except more performance at heavy loads (which hopefully they too won't either).

Some tests ran:
| Test | Before | After | Win |
|---|---|---|---|
| Timestamp ticker, 1000-line group window | ~26ms | ~11ms | 2.1-3.2x |
| Timestamp ticker + emote retry, 300-line/40-sender group | 7.9ms | 3.2ms | 2.4x |
| Profile rename redraw, same 300-line/40-sender group | 7.1ms (blanket, every window) | 0.76ms (targeted, just the changed player) | 9.3x |