### PR TITLE
Change "Enable Mouse" to "Enable Hyperlinks"

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -58,7 +58,7 @@ L = {
 
 	WINDOW_OPTIONS = "Window Options",
 	ENABLE_MOUSE = "Enable Hyperlinks",
-	ENABLE_MOUSE_HELP = "Toggles the ability to click hyperlinks, such as items and URLs, in the Eavesdropper window.",
+	ENABLE_MOUSE_HELP = "Toggles the ability to interact with hyperlinks, such as items and URLs, in the Eavesdropper window.",
 	LOCK_SCROLL = "Lock Scrolling",
 	LOCK_SCROLL_HELP = "Disables the ability to scroll through the message history.|n|n- Use this to ensure Eavesdropper always remains at the bottom of the list to show the latest messages.",
 	LOCK_WINDOW = "Lock Moving",

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -57,8 +57,8 @@ L = {
 	FILTER_ROLLS = "Rolls",
 
 	WINDOW_OPTIONS = "Window Options",
-	ENABLE_MOUSE = "Enable Mouse",
-	ENABLE_MOUSE_HELP = "Toggles whether you can interact with the Eavesdropper window using your mouse.|n|n- Enabled: Allows you to click on item links and URLs within the history.|n- Disabled: Clicks pass through the window to the game world behind it, preventing accidental clicks during gameplay.",
+	ENABLE_MOUSE = "Enable Hyperlinks",
+	ENABLE_MOUSE_HELP = "Toggles the ability to click hyperlinks, such as items and URLs, in the Eavesdropper window.",
 	LOCK_SCROLL = "Lock Scrolling",
 	LOCK_SCROLL_HELP = "Disables the ability to scroll through the message history.|n|n- Use this to ensure Eavesdropper always remains at the bottom of the list to show the latest messages.",
 	LOCK_WINDOW = "Lock Moving",

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -59,7 +59,7 @@ L = {
 
 	WINDOW_OPTIONS = "Options de la fenêtre",
 	ENABLE_MOUSE = "Activer les liens",
-	ENABLE_MOUSE_HELP = "Autorise le clic sur les liens (objets, URLs, etc.) dans la fenêtre d'Eavesdropper.",
+	ENABLE_MOUSE_HELP = "Autorise l'interaction avec les liens (objets, URLs, etc.) dans la fenêtre d'Eavesdropper.",
 	LOCK_SCROLL = "Verrouiller le défilement",
 	LOCK_SCROLL_HELP = "Désactive le défilement dans l'historique des messages.|n|n- Utilisez cette option pour vous assurer qu'Eavesdropper reste toujours en bas de la liste afin d'afficher les derniers messages.",
 	LOCK_WINDOW = "Verrouiller la fenêtre",

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -58,8 +58,8 @@ L = {
 	FILTER_ROLLS = "Rolls",
 
 	WINDOW_OPTIONS = "Options de la fenêtre",
-	ENABLE_MOUSE = "Activer la souris",
-	ENABLE_MOUSE_HELP = "Détermine si vous pouvez interagir avec la fenêtre d'Eavesdropper avec la souris.|n|n- Activée : Permet de cliquer sur les liens d'objets et les URLs dans l'historique.|n- Désactivée : Les clics traversent la fenêtre, évitant toute interaction accidentelle.",
+	ENABLE_MOUSE = "Activer les liens",
+	ENABLE_MOUSE_HELP = "Active ou désactive la possibilité de cliquer sur les liens hypertextes, tels que les objets et les hauts faits, dans la fenêtre d'Eavesdropper.",
 	LOCK_SCROLL = "Verrouiller le défilement",
 	LOCK_SCROLL_HELP = "Désactive le défilement dans l'historique des messages.|n|n- Utilisez cette option pour vous assurer qu'Eavesdropper reste toujours en bas de la liste afin d'afficher les derniers messages.",
 	LOCK_WINDOW = "Verrouiller la fenêtre",

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -59,7 +59,7 @@ L = {
 
 	WINDOW_OPTIONS = "Options de la fenêtre",
 	ENABLE_MOUSE = "Activer les liens",
-	ENABLE_MOUSE_HELP = "Active ou désactive la possibilité de cliquer sur les liens hypertextes, tels que les objets et les hauts faits, dans la fenêtre d'Eavesdropper.",
+	ENABLE_MOUSE_HELP = "Autorise le clic sur les liens (objets, URLs, etc.) dans la fenêtre d'Eavesdropper.",
 	LOCK_SCROLL = "Verrouiller le défilement",
 	LOCK_SCROLL_HELP = "Désactive le défilement dans l'historique des messages.|n|n- Utilisez cette option pour vous assurer qu'Eavesdropper reste toujours en bas de la liste afin d'afficher les derniers messages.",
 	LOCK_WINDOW = "Verrouiller la fenêtre",

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -58,8 +58,8 @@ L = {
 	FILTER_ROLLS = "Ролл",
 
 	WINDOW_OPTIONS = "Параметры окна",
-	ENABLE_MOUSE = "Взаимодействие мышью",
-	ENABLE_MOUSE_HELP = "Toggles whether you can interact with the Eavesdropper window using your mouse.|n|n- Enabled: Allows you to click on item links and URLs within the history.|n- Disabled: Clicks pass through the window to the game world behind it, preventing accidental clicks during gameplay.", -- NEW
+	ENABLE_MOUSE = "Включить ссылки",
+	ENABLE_MOUSE_HELP = "Включение и выключение возможности кликать по гиперссылкам (например, на предметы и достижения) в окне Eavesdropper.",
 	LOCK_SCROLL = "Блокировка прокрутки",
 	LOCK_SCROLL_HELP = "Отключает возможность прокрутки истории сообщений.|n|n- Используйте это, чтобы окно всегда оставалось в самом низу и показывало только свежие сообщения.",
 	LOCK_WINDOW = "Закрепить окно",

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -535,22 +535,13 @@ function Eavesdropper_SharedFrameMixin:UpdateMouseLock()
 	-- Always keep the frame itself mouse-enabled so OnEnter/OnLeave still fire
 	self:EnableMouse(true);
 
-	if not isEnabled then
-		-- Ghost mode: pass all clicks and motion through to the world
-		self:SetPropagateMouseClicks(true);
-		self:SetPropagateMouseMotion(true);
+	-- Pass clicks and motion through to the world
+	-- Unless they land on Jump, Sender, or enabled Hyperlink
+	self:SetPropagateMouseClicks(true);
+	self:SetPropagateMouseMotion(true);
 
-		if self.SetMouseMotionEnabled then
-			self:SetMouseMotionEnabled(true);
-		end
-	else
-		-- Normal mode: consume clicks, block world interaction
-		self:SetPropagateMouseClicks(false);
-		self:SetPropagateMouseMotion(false);
-
-		if self.SetMouseMotionEnabled then
-			self:SetMouseMotionEnabled(true);
-		end
+	if self.SetMouseMotionEnabled then
+		self:SetMouseMotionEnabled(true);
 	end
 
 	-- SetHyperlinksEnabled stays true when exempt so edjump/player can still hit-test; OnHyperlinkClick/

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -559,7 +559,6 @@ function Eavesdropper_SharedFrameMixin:UpdateMouseLock()
 
 	-- This delay is essential otherwise it won't take effect
 	RunNextFrame(function()
-		self:SetHyperlinksEnabled(hyperlinksEnabled);
 		if self.ChatBox then
 			self.ChatBox:SetHyperlinksEnabled(hyperlinksEnabled);
 		end

--- a/UI/EavesdropperFrameShared.lua
+++ b/UI/EavesdropperFrameShared.lua
@@ -503,7 +503,14 @@ function Eavesdropper_SharedFrameMixin:OnHyperlinkEnter(link, text, region, left
 	if linkType == "player" then
 		if not width or not height then return; end
 		NameHoverHighlight_Show(region, left, bottom, width, height);
+		return;
 	end
+
+	-- Otherwise try showing a tooltip on the top right
+	GameTooltip:SetOwner(self, "ANCHOR_PRESERVE");
+	GameTooltip:ClearAllPoints();
+	GameTooltip:SetPoint("BOTTOMLEFT", region, "TOPLEFT", left + width, bottom);
+	GameTooltip:SetHyperlink(link);
 end
 
 function Eavesdropper_SharedFrameMixin:OnHyperlinkLeave()


### PR DESCRIPTION
- ED windows now always allow mouse clicks to pass through unless:
  - Clicking on Jump to Sender.
  - Clicking on hyperlinks when **Enable Hyperlinks** is enabled.

- Updated the option's label and tooltip.

<img width="624" height="330" alt="EnableHyperlinksTooltip" src="https://github.com/user-attachments/assets/1e854418-fa14-4183-bde5-da661fbe20b8" />
